### PR TITLE
Re-rendering of user liked songs list & cleaner implementation for liking/disliking song

### DIFF
--- a/lib/API/musify.dart
+++ b/lib/API/musify.dart
@@ -31,6 +31,9 @@ Map activePlaylist = {
   'list': [],
 };
 
+late final currentLikedSongsLength =
+ValueNotifier<int>(userLikedSongsList.length);
+
 final lyrics = ValueNotifier<String>('null');
 String lastFetchedLyrics = 'null';
 

--- a/lib/screens/user_liked_songs_page.dart
+++ b/lib/screens/user_liked_songs_page.dart
@@ -116,22 +116,26 @@ class _UserLikedSongsState extends State<UserLikedSongs> {
               ],
             ),
             const Padding(padding: EdgeInsets.only(top: 20)),
-            ListView.builder(
-              shrinkWrap: true,
-              physics: const BouncingScrollPhysics(),
-              addAutomaticKeepAlives: false,
-              addRepaintBoundaries: false,
-              itemCount: userLikedSongsList.length,
-              itemBuilder: (BuildContext context, int index) {
-                return Padding(
-                  padding: const EdgeInsets.only(top: 5, bottom: 5),
-                  child: SongBar(
-                    userLikedSongsList[index],
-                    true,
-                  ),
-                );
-              },
-            )
+            ValueListenableBuilder(
+                valueListenable: currentLikedSongsLength,
+                builder: (_, value, __) {
+                  return ListView.builder(
+                    shrinkWrap: true,
+                    physics: const BouncingScrollPhysics(),
+                    addAutomaticKeepAlives: false,
+                    addRepaintBoundaries: false,
+                    itemCount: userLikedSongsList.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      return Padding(
+                        padding: const EdgeInsets.only(top: 5, bottom: 5),
+                        child: SongBar(
+                          userLikedSongsList[index],
+                          true,
+                        ),
+                      );
+                    },
+                  );
+                })
           ],
         ),
       ),

--- a/lib/widgets/song_bar.dart
+++ b/lib/widgets/song_bar.dart
@@ -5,8 +5,6 @@ import 'package:musify/API/musify.dart';
 import 'package:musify/services/audio_manager.dart';
 import 'package:musify/services/download_manager.dart';
 import 'package:musify/style/app_themes.dart';
-late final currentLikedSongsLength =
-ValueNotifier<int>(userLikedSongsList.length);
 
 class SongBar extends StatelessWidget {
   SongBar(this.song, this.clearPlaylist, {super.key});

--- a/lib/widgets/song_bar.dart
+++ b/lib/widgets/song_bar.dart
@@ -5,12 +5,19 @@ import 'package:musify/API/musify.dart';
 import 'package:musify/services/audio_manager.dart';
 import 'package:musify/services/download_manager.dart';
 import 'package:musify/style/app_themes.dart';
+late final currentLikedSongsLength =
+ValueNotifier<int>(userLikedSongsList.length);
 
 class SongBar extends StatelessWidget {
   SongBar(this.song, this.clearPlaylist, {super.key});
-
   late final dynamic song;
   late final bool clearPlaylist;
+
+  final likeStatusToIconMapper = {
+    true: FluentIcons.star_24_filled,
+    false: FluentIcons.star_24_regular
+  };
+
   late final songLikeStatus =
       ValueNotifier<bool>(isSongAlreadyLiked(song['ytid']));
 
@@ -99,25 +106,19 @@ class SongBar extends StatelessWidget {
                 ValueListenableBuilder<bool>(
                   valueListenable: songLikeStatus,
                   builder: (_, value, __) {
-                    if (value == true) {
-                      return IconButton(
-                        color: colorScheme.primary,
-                        icon: const Icon(FluentIcons.star_24_filled),
-                        onPressed: () => {
-                          updateLikeStatus(song['ytid'], false),
-                          songLikeStatus.value = false
-                        },
-                      );
-                    } else {
-                      return IconButton(
-                        color: colorScheme.primary,
-                        icon: const Icon(FluentIcons.star_24_regular),
-                        onPressed: () => {
-                          updateLikeStatus(song['ytid'], true),
-                          songLikeStatus.value = true
-                        },
-                      );
-                    }
+                    return IconButton(
+                      onPressed: () => {
+                        songLikeStatus.value = !songLikeStatus.value,
+                        updateLikeStatus(
+                          song['ytid'],
+                          songLikeStatus.value,
+                        ),
+                        currentLikedSongsLength.value = value
+                            ? currentLikedSongsLength.value + 1
+                            : currentLikedSongsLength.value - 1
+                      },
+                      icon: Icon(likeStatusToIconMapper[value]),
+                    );
                   },
                 ),
                 IconButton(


### PR DESCRIPTION
I have made two changes. 

1.  Reduced the unnecessary else portion in the SongBar widget and wrote the liking/unliking a song in a cleaner way.
2. Rerendered the liked songs list whenever the user dislikes a song on the user-liked songs list. Previously, we needed to go back 
and come again on the screen to see the changes. I have done this using ValueNotifier. 

Please provide feedback and if you find these changes helpful, then merge the code