### PR TITLE
Use flutter version of pubspec.yaml for F-Droid build

### DIFF
--- a/.github/workflows/fdroid.yml
+++ b/.github/workflows/fdroid.yml
@@ -26,9 +26,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       # Setup the flutter environment.
+      - run: |
+          pip install -U yq
+          echo "FLUTTER_VERSION=$(yq -r .environment.flutter pubspec.yaml | sed 's/\^//g')" >> $GITHUB_ENV
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: "${{ env.FLUTTER_VERSION }}"
       #
       - run: |
           echo keyPassword=\${{ secrets.KEY_STORE }} > ${{env.PROPERTIES_PATH}}


### PR DESCRIPTION
_Related to https://github.com/gokadzev/Musify/discussions/165 discussion._

The build on Github and F-Droid could end in using different flutter versions, thus fail a reproducible build. A way to prevent this is using the flutter version specified in pathspec.yaml on both ends.

This solution is very likely not perfect, but should work on each side.

Other builds don't need this since this is for keeping GH and F-Droid in sync only.

