### PR TITLE
Feat: Support for monochrome/themed icon

### DIFF
--- a/android/app/src/main/res/mipmap-anydpi-v26/launcher_icon.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/launcher_icon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
   <background android:drawable="@color/ic_launcher_background"/>
   <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+  <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/lib/screens/player.dart
+++ b/lib/screens/player.dart
@@ -1,3 +1,4 @@
+import 'package:audio_service/audio_service.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
@@ -10,6 +11,7 @@ import 'package:musify/services/audio_manager.dart';
 import 'package:musify/services/download_manager.dart';
 import 'package:musify/services/settings_manager.dart';
 import 'package:musify/style/app_themes.dart';
+import 'package:musify/utilities/mediaitem.dart';
 import 'package:musify/widgets/marque.dart';
 import 'package:musify/widgets/song_bar.dart';
 import 'package:musify/widgets/spinner.dart';
@@ -283,10 +285,7 @@ class AudioAppState extends State<AudioApp> {
                                     ),
                                     onPressed: () => downloadSong(
                                       context,
-                                      getSongDetails(
-                                        0,
-                                        metadata.extras['ytid'].toString(),
-                                      ),
+                                      mediaItemToMap(metadata as MediaItem),
                                     ),
                                   ),
                                   ValueListenableBuilder<bool>(

--- a/lib/screens/player.dart
+++ b/lib/screens/player.dart
@@ -1,4 +1,3 @@
-import 'package:audio_service/audio_service.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
@@ -11,7 +10,6 @@ import 'package:musify/services/audio_manager.dart';
 import 'package:musify/services/download_manager.dart';
 import 'package:musify/services/settings_manager.dart';
 import 'package:musify/style/app_themes.dart';
-import 'package:musify/utilities/mediaitem.dart';
 import 'package:musify/widgets/marque.dart';
 import 'package:musify/widgets/song_bar.dart';
 import 'package:musify/widgets/spinner.dart';
@@ -285,7 +283,10 @@ class AudioAppState extends State<AudioApp> {
                                     ),
                                     onPressed: () => downloadSong(
                                       context,
-                                      mediaItemToMap(metadata as MediaItem),
+                                      getSongDetails(
+                                        0,
+                                        metadata.extras['ytid'].toString(),
+                                      ),
                                     ),
                                   ),
                                   ValueListenableBuilder<bool>(


### PR DESCRIPTION
This commit adds support for themed icons on Android 13. For more information see [user theming](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive).

![Screenshot](https://github.com/gokadzev/Musify/assets/115667885/b757c9b4-3f5e-4e5a-b253-55dcaf349fd3)
