### PR TITLE
CustomPlaylists load again!

### DIFF
--- a/lib/screens/user_added_playlists_page.dart
+++ b/lib/screens/user_added_playlists_page.dart
@@ -171,12 +171,13 @@ class _UserPlaylistsPageState extends State<UserPlaylistsPage> {
                   ),
                   itemBuilder: (BuildContext context, index) {
                     final playlist = playlists[index];
-                    final ytid = playlist['ytid'].toString();
+                    final ytid = playlist['ytid'];
 
                     return Center(
                       child: GestureDetector(
                         onLongPress: () {
-                          removeUserPlaylist(ytid);
+                          if(ytid == null && playlist['isCustom']) removeUserCustomPlaylist(playlist);
+                          else removeUserPlaylist(ytid);
                           setState(() {});
                         },
                         child: PlaylistCube(


### PR DESCRIPTION
Modified so Custom Playlists load again (and are not stuck) and custom playlists are removable!  The problem was that the conversion of "yitd" to String made it so that it's content is 'null' instead of null, which rendered multiple checks useless. My guess is that the change was done because the playlistRemoveFunction requiers a non nullable string. Therefore a new (working) remove function was also written.