### PR TITLE
Bring package back to AndroidManifest.xml

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.gokadzev.musify">
 
      <queries>
         <intent>


### PR DESCRIPTION
Bring package back to AndroidManifest.xml to bypass "No application found for TargetPlatform.android_arm64" error when build the app on M1 chipset
