### PR TITLE
Fix: Music resumes after call, only if it was playing before

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -53,6 +53,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
   Timer? _sleepTimer;
   bool sleepTimerExpired = false;
+  late bool wasPlayingBeforeCall = false;
 
   late StreamSubscription<PlaybackEvent> _playbackEventSubscription;
   late StreamSubscription<Duration?> _durationSubscription;
@@ -188,6 +189,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
       await session.configure(const AudioSessionConfiguration.music());
       session.interruptionEventStream.listen((event) async {
         if (event.begin) {
+          wasPlayingBeforeCall = audioPlayer.playing;
           switch (event.type) {
             case AudioInterruptionType.duck:
               await audioPlayer.setVolume(0.5);
@@ -203,7 +205,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
               await audioPlayer.setVolume(1);
               break;
             case AudioInterruptionType.pause:
-              await audioPlayer.play();
+              if (wasPlayingBeforeCall) await audioPlayer.play();
               break;
             case AudioInterruptionType.unknown:
               break;


### PR DESCRIPTION
## Problem
- When a call comes in, the music pauses automatically, which is fine.
- However, even if the music was **paused before the call**, it **resumes playing** after the call ends.
- This means the user has to manually pause it again, which is unexpected behavior.

## Expected Behavior
- If the music was **already paused before the call**, it should **remain paused** after the call ends.
- If the music **was playing before the call**, it should **resume playback** as expected.

## Fix
- Store the playback state before the call.
- Only resume playback if it was playing before the call.
