### PR TITLE
fix(ui): adjust spacing in mobile layout by commenting out SizedBox

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,6 +38,12 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging true
+        }
+    }
+
     kotlinOptions {
         jvmTarget = '17'
     }
@@ -57,6 +63,7 @@ android {
         targetSdk 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        multiDexEnabled = true
     }
 
     flavorDimensions "flavor"
@@ -98,7 +105,12 @@ android {
     buildTypes {
         release {
             signingConfig signingConfigs.release
-            shrinkResources false
+            minifyEnabled = true
+            shrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
         debug {
             applicationIdSuffix '.debug'
@@ -110,5 +122,10 @@ android {
 
 flutter {
     source '../..'
+}
+
+
+dependencies {
+    implementation("androidx.multidex:multidex:2.0.1")
 }
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,31 @@
+#Flutter Wrapper
+-keep class io.flutter.app.** { *; }
+-keep class io.flutter.plugin.**  { *; }
+-keep class io.flutter.util.**  { *; }
+-keep class io.flutter.view.**  { *; }
+-keep class io.flutter.**  { *; }
+-keep class io.flutter.plugins.**  { *; }
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+
+# To ignore minifyEnabled: true error
+# https://github.com/flutter/flutter/issues/19250
+# https://github.com/flutter/flutter/issues/37441
+-ignorewarnings
+-keep class * {
+    public private *;
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,9 +33,7 @@
         android:label="Musify"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:enableOnBackInvokedCallback="true"
-        android:extractNativeLibs="true"
-        tools:replace="android:extractNativeLibs">
+        android:enableOnBackInvokedCallback="true">
 
         <!-- AudioServiceActivity -->
         <activity

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -142,6 +142,7 @@ class _MusifyState extends State<Musify> {
         const SystemUiOverlayStyle(
           statusBarColor: Colors.transparent,
           systemNavigationBarColor: Colors.transparent,
+          systemStatusBarContrastEnforced: true,
         ),
       );
     });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -187,28 +187,30 @@ class _MusifyState extends State<Musify> {
 
   @override
   Widget build(BuildContext context) {
-    return DynamicColorBuilder(
-      builder: (lightColorScheme, darkColorScheme) {
-        final colorScheme = getAppColorScheme(
-          lightColorScheme,
-          darkColorScheme,
-        );
+    return SafeArea(
+      child: DynamicColorBuilder(
+        builder: (lightColorScheme, darkColorScheme) {
+          final colorScheme = getAppColorScheme(
+            lightColorScheme,
+            darkColorScheme,
+          );
 
-        return MaterialApp.router(
-          themeMode: themeMode,
-          darkTheme: getAppTheme(colorScheme),
-          theme: getAppTheme(colorScheme),
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-          ],
-          supportedLocales: appSupportedLocales,
-          locale: languageSetting,
-          routerConfig: NavigationManager.router,
-        );
-      },
+          return MaterialApp.router(
+            themeMode: themeMode,
+            darkTheme: getAppTheme(colorScheme),
+            theme: getAppTheme(colorScheme),
+            localizationsDelegates: const [
+              AppLocalizations.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+            ],
+            supportedLocales: appSupportedLocales,
+            locale: languageSetting,
+            routerConfig: NavigationManager.router,
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/screens/now_playing_page.dart
+++ b/lib/screens/now_playing_page.dart
@@ -177,7 +177,7 @@ class _MobileLayout extends StatelessWidget {
             iconSize: adjustedMiniIconSize,
             isLargeScreen: isLargeScreen,
           ),
-          const SizedBox(height: 35),
+          // const SizedBox(height: 35),
         ],
       ],
     );

--- a/lib/screens/now_playing_page.dart
+++ b/lib/screens/now_playing_page.dart
@@ -155,10 +155,9 @@ class _MobileLayout extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
+      spacing: 10,
       children: [
-        const SizedBox(height: 10),
         NowPlayingArtwork(size: size, metadata: metadata),
-        const SizedBox(height: 10),
         if (!(metadata.extras?['isLive'] ?? false))
           NowPlayingControls(
             context: context,
@@ -169,7 +168,6 @@ class _MobileLayout extends StatelessWidget {
             metadata: metadata,
           ),
         if (!isLargeScreen) ...[
-          const SizedBox(height: 10),
           BottomActionsRow(
             context: context,
             audioId: metadata.extras?['ytid'],
@@ -177,7 +175,7 @@ class _MobileLayout extends StatelessWidget {
             iconSize: adjustedMiniIconSize,
             isLargeScreen: isLargeScreen,
           ),
-          // const SizedBox(height: 35),
+          const SizedBox(height: 2),
         ],
       ],
     );


### PR DESCRIPTION
Some UI issues related to the device bar covers the app area, so using a safearea to resolve the issue

![Screenshot 2025-05-26 at 9 19 31 PM](https://github.com/user-attachments/assets/bb5b0b97-85ea-42da-9ed4-2119ed71833f)
![Screenshot 2025-05-26 at 9 22 58 PM](https://github.com/user-attachments/assets/bdb54fe6-5702-4993-8f52-1314bc9fe718)

After applying the safearea, there is a hardcode sized container with a height that causes the widget overflow, so removing it.

![Screenshot 2025-05-26 at 9 19 11 PM](https://github.com/user-attachments/assets/8e092309-b639-41fe-95fb-9778fb533367)
![Screenshot 2025-05-26 at 9 19 05 PM](https://github.com/user-attachments/assets/dae9b64d-7033-4be2-a783-66aecac4e1d0)
![Screenshot 2025-05-26 at 9 28 18 PM](https://github.com/user-attachments/assets/cb592026-3dfa-4d71-bbff-2454a6062bea)

After applying these changes, I have tested with android devices of different sizes, and it should be fine!
