### PR TITLE
make the github release action honor the flutter version from pubspec.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,13 @@ jobs:
             ${{ runner.os }}-gradle-
 
       # Setup the Flutter environment.
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+      - run: |
+          pip install -U yq
+          echo "FLUTTER_VERSION=$(yq -r .environment.flutter pubspec.yaml | sed 's/\^//g')" >> $GITHUB_ENV
+      - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: "${{ env.FLUTTER_VERSION }}"
 
       #
       - run: |


### PR DESCRIPTION
v9.6.3 failed RB, because your release action wasn't pinned to the flutter version specified in `pubspec.yaml`, and thus used the "currently latest stable available". This PR adjust the workflow, based on the fdroid one, so future releases will be RB again without manual intervention (hopefully :wink:)

For 9.6.3, we've manually corrected it in our build recipe, so it is RB again.