### PR TITLE
feat: add offline search functionality

### DIFF
--- a/lib/screens/bottom_navigation_page.dart
+++ b/lib/screens/bottom_navigation_page.dart
@@ -143,22 +143,13 @@ class _BottomNavigationPageState extends State<BottomNavigationPage> {
         route: '/home',
         shellIndex: 0,
       ),
-    ];
-
-    // Only add search tab in online mode
-    if (!isOfflineMode) {
-      items.add(
-        _NavigationItem(
-          icon: FluentIcons.search_24_regular,
-          selectedIcon: FluentIcons.search_24_filled,
-          label: context.l10n?.search ?? 'Search',
-          route: '/search',
-          shellIndex: 1,
-        ),
-      );
-    }
-
-    items.addAll([
+      _NavigationItem(
+        icon: FluentIcons.search_24_regular,
+        selectedIcon: FluentIcons.search_24_filled,
+        label: context.l10n?.search ?? 'Search',
+        route: '/search',
+        shellIndex: 1,
+      ),
       _NavigationItem(
         icon: FluentIcons.book_24_regular,
         selectedIcon: FluentIcons.book_24_filled,
@@ -173,21 +164,13 @@ class _BottomNavigationPageState extends State<BottomNavigationPage> {
         route: '/settings',
         shellIndex: 3,
       ),
-    ]);
+    ];
 
     return items;
   }
 
   void _handleOfflineModeChange(bool isOfflineMode) {
-    if (!mounted) return;
-
-    final currentRoute = GoRouterState.of(context).matchedLocation;
-
-    // If we're switching to offline mode and currently on search tab
-    if (isOfflineMode && currentRoute.startsWith('/search')) {
-      // Navigate to home
-      widget.child.goBranch(0);
-    }
+    // No longer need to navigate away from search in offline mode
   }
 
   void _onTabTapped(int index, List<_NavigationItem> items) {
@@ -220,10 +203,6 @@ class _BottomNavigationPageState extends State<BottomNavigationPage> {
       (item) => item.shellIndex == currentShellIndex,
     );
     if (matchedIndex != -1) return matchedIndex;
-
-    // If the Search branch (1) is active but Search is hidden in offline mode,
-    // fall back to the Home tab.
-    if (isOfflineMode && currentShellIndex == 1) return 0;
 
     // Final fallback: return the first tab to keep UI in a valid state.
     return 0;

--- a/lib/screens/search_page.dart
+++ b/lib/screens/search_page.dart
@@ -29,6 +29,7 @@ import 'package:musify/main.dart';
 import 'package:musify/services/common_services.dart';
 import 'package:musify/services/data_manager.dart';
 import 'package:musify/services/playlists_manager.dart';
+import 'package:musify/services/settings_manager.dart';
 import 'package:musify/utilities/common_variables.dart';
 import 'package:musify/utilities/utils.dart';
 import 'package:musify/widgets/confirmation_dialog.dart';
@@ -64,6 +65,8 @@ class _SearchPageState extends State<SearchPage> {
   List<dynamic> _songsSearchResult = [];
   List<dynamic> _albumsSearchResult = [];
   List<dynamic> _playlistsSearchResult = [];
+  List<dynamic> _offlineSongsResult = [];
+  List<dynamic> _librarySongsResult = [];
   List<String> _suggestionsList = [];
   Timer? _debounce;
   int _latestSuggestionRequest = 0;
@@ -101,6 +104,8 @@ class _SearchPageState extends State<SearchPage> {
       _songsSearchResult = [];
       _albumsSearchResult = [];
       _playlistsSearchResult = [];
+      _offlineSongsResult = [];
+      _librarySongsResult = [];
       _suggestionsList = [];
       if (mounted) setState(() {});
       return;
@@ -114,15 +119,25 @@ class _SearchPageState extends State<SearchPage> {
     }
 
     try {
-      _songsSearchResult = await fetchSongsList(query);
-      _albumsSearchResult = await getPlaylists(query: query, type: 'album');
-      _playlistsSearchResult = await getPlaylists(
-        query: query,
-        type: 'playlist',
-      );
+      // Offline/Local Search (Intelligent search)
+      _offlineSongsResult = _intelligentLocalSearch(userOfflineSongs, query);
+      _librarySongsResult = _intelligentLocalSearch(userLikedSongsList, query);
+
+      if (!offlineMode.value) {
+        _songsSearchResult = await fetchSongsList(query);
+        _albumsSearchResult = await getPlaylists(query: query, type: 'album');
+        _playlistsSearchResult = await getPlaylists(
+          query: query,
+          type: 'playlist',
+        );
+      } else {
+        _songsSearchResult = [];
+        _albumsSearchResult = [];
+        _playlistsSearchResult = [];
+      }
     } catch (e, stackTrace) {
       logger.log(
-        'Error while searching online songs',
+        'Error while searching songs',
         error: e,
         stackTrace: stackTrace,
       );
@@ -130,6 +145,24 @@ class _SearchPageState extends State<SearchPage> {
       _fetchingSongs.value = false;
       if (mounted) setState(() {});
     }
+  }
+
+  List<dynamic> _intelligentLocalSearch(List source, String query) {
+    if (query.isEmpty) return [];
+    final lowercaseQuery = query.toLowerCase();
+    final queryWords = lowercaseQuery.split(RegExp(r'\s+')).where((w) => w.isNotEmpty).toList();
+
+    return source.where((song) {
+      final title = (song['title'] ?? '').toString().toLowerCase();
+      final artist = (song['artist'] ?? '').toString().toLowerCase();
+      final album = (song['album'] ?? '').toString().toLowerCase();
+
+      // Check if all words in query are present in either title, artist or album
+      return queryWords.every((word) =>
+          title.contains(word) ||
+          artist.contains(word) ||
+          album.contains(word));
+    }).toList();
   }
 
   @override
@@ -162,18 +195,23 @@ class _SearchPageState extends State<SearchPage> {
                         const Duration(milliseconds: 300),
                         () async {
                           if (query.isNotEmpty) {
-                            final searchSuggestions =
-                                await getSearchSuggestions(query);
+                            if (!offlineMode.value) {
+                              final searchSuggestions =
+                                  await getSearchSuggestions(query);
 
-                            if (!mounted ||
-                                requestId != _latestSuggestionRequest ||
-                                _searchBar.text != query) {
-                              return;
+                              if (!mounted ||
+                                  requestId != _latestSuggestionRequest ||
+                                  _searchBar.text != query) {
+                                return;
+                              }
+
+                              _suggestionsList = List<String>.from(
+                                searchSuggestions,
+                              );
+                            } else {
+                              // Minimal suggestions for offline? Maybe just history
+                              _suggestionsList = [];
                             }
-
-                            _suggestionsList = List<String>.from(
-                              searchSuggestions,
-                            );
                           } else {
                             if (requestId != _latestSuggestionRequest) {
                               return;
@@ -206,7 +244,9 @@ class _SearchPageState extends State<SearchPage> {
                   (_suggestionsList.isNotEmpty ||
                       (_songsSearchResult.isEmpty &&
                           _albumsSearchResult.isEmpty &&
-                          _playlistsSearchResult.isEmpty))
+                          _playlistsSearchResult.isEmpty &&
+                          _offlineSongsResult.isEmpty &&
+                          _librarySongsResult.isEmpty))
                   ? ValueListenableBuilder<List>(
                       valueListenable: searchHistoryNotifier,
                       builder: (context, searchHistory, _) {
@@ -275,7 +315,63 @@ class _SearchPageState extends State<SearchPage> {
   Widget _buildSearchResults(BuildContext context, Color primaryColor) {
     final widgets = <Widget>[];
 
-    // Songs section
+    // Offline Songs section
+    if (_offlineSongsResult.isNotEmpty) {
+      widgets.add(
+        SectionTitle(
+          context.l10n!.offlineSongs,
+          primaryColor,
+          icon: FluentIcons.cellular_off_24_filled,
+        ),
+      );
+
+      final count = _offlineSongsResult.length > maxSongsInList
+          ? maxSongsInList
+          : _offlineSongsResult.length;
+
+      for (var index = 0; index < count; index++) {
+        final borderRadius = getItemBorderRadius(index, count);
+        widgets.add(
+          SongBar(
+            _offlineSongsResult[index],
+            true,
+            key: ValueKey('offline_song_${_offlineSongsResult[index]['ytid']}_$index'),
+            showMusicDuration: true,
+            borderRadius: borderRadius,
+          ),
+        );
+      }
+    }
+
+    // Library Songs section (Liked)
+    if (_librarySongsResult.isNotEmpty) {
+      widgets.add(
+        SectionTitle(
+          context.l10n!.likedSongs,
+          primaryColor,
+          icon: FluentIcons.heart_24_filled,
+        ),
+      );
+
+      final count = _librarySongsResult.length > maxSongsInList
+          ? maxSongsInList
+          : _librarySongsResult.length;
+
+      for (var index = 0; index < count; index++) {
+        final borderRadius = getItemBorderRadius(index, count);
+        widgets.add(
+          SongBar(
+            _librarySongsResult[index],
+            true,
+            key: ValueKey('library_song_${_librarySongsResult[index]['ytid']}_$index'),
+            showMusicDuration: true,
+            borderRadius: borderRadius,
+          ),
+        );
+      }
+    }
+
+    // Songs section (Online)
     if (_songsSearchResult.isNotEmpty) {
       widgets.add(
         SectionTitle(
@@ -370,7 +466,7 @@ class _SearchPageState extends State<SearchPage> {
 
     return Column(
       key: ValueKey(
-        'results-${_songsSearchResult.length}-${_albumsSearchResult.length}-${_playlistsSearchResult.length}',
+        'results-${_songsSearchResult.length}-${_albumsSearchResult.length}-${_playlistsSearchResult.length}-${_offlineSongsResult.length}-${_librarySongsResult.length}',
       ),
       children: widgets,
     );


### PR DESCRIPTION
## Description
This PR adds a much-needed offline search feature for downloaded and liked songs. 

Previously, if the user was offline, the Search tab would disappear or become unusable. Now, users can easily search through their locally saved music library without needing an internet connection.

## Changes made
- **`bottom_navigation_page.dart`**: Removed the condition that hid the Search tab when `isOfflineMode` was active. The tab is now always visible. Removed the fallback that forced navigation to the Home tab when going offline.
- **`search_page.dart`**: Added `_intelligentLocalSearch` to filter through `userOfflineSongs` and `userLikedSongsList`. It splits the search query into words and matches them against track titles, artists, and albums regardless of word order.
- **UI Updates**: Added visual sections for "Offline Songs" and "Liked Songs" using the existing localization keys (`context.l10n!.offlineSongs` and `context.l10n!.likedSongs`), so translations work out of the box via Crowdin without requiring new `.arb` entries.

## How to test
1. Enable Offline Mode in the app settings (or turn off Wi-Fi/Data).
2. Go to the Search tab (it will now be visible).
3. Type the name, artist, or album of a song you have previously downloaded or liked.
4. The results will populate instantly under the "Offline Songs" and "Liked Songs" headers.
