### PR TITLE
feat(user_songs): add shuffle play button for library categories

### DIFF
--- a/lib/screens/user_songs_page.dart
+++ b/lib/screens/user_songs_page.dart
@@ -189,6 +189,7 @@ class _UserSongsPageState extends State<UserSongsPage> {
           runSpacing: 8,
           children: [
             if (songsLength > 0) _buildPlayButton(primaryColor, title),
+            if (songsLength > 0) _buildShufflePlayButton(primaryColor),
             if (isRecentlyPlayed && songsLength > 0)
               _buildClearRecentsButton(primaryColor),
           ],
@@ -273,6 +274,29 @@ class _UserSongsPageState extends State<UserSongsPage> {
       iconSize: 24,
       onPressed: () =>
           audioHandler.playPlaylistSong(playlist: playlist, songIndex: 0),
+    );
+  }
+
+  Widget _buildShufflePlayButton(Color primaryColor) {
+    return IconButton.filledTonal(
+      icon: Icon(FluentIcons.arrow_shuffle_24_filled, color: primaryColor),
+      iconSize: 24,
+      tooltip: 'Shuffle play',
+      onPressed: () async {
+        final songsList = getSongsList(widget.page);
+        if (songsList.isEmpty) return;
+
+        final shuffledSongs = List<Map>.from(songsList.whereType<Map>());
+        if (shuffledSongs.isEmpty) return;
+
+        shuffledSongs.shuffle();
+
+        await audioHandler.addPlaylistToQueue(
+          shuffledSongs,
+          replace: true,
+          startIndex: 0,
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## Description
This PR introduces a **Shuffle play** button to the header section of the User Songs pages (Liked songs, Offline songs, and Recently played).

## Changes made
- Added a new `_buildShufflePlayButton` widget alongside the existing Play and Clear buttons.
- The function securely creates a copy of the current songs list, applies Dart's native `.shuffle()`, and replaces the current queue with it.
- Follows the app's current UI design by utilizing `IconButton.filledTonal` and `FluentIcons.arrow_shuffle_24_filled`.

This is a small but very useful feature, especially for users with large offline/liked libraries who want a quick way to listen to their tracks in random order. Thank you!