### PR TITLE
ui: make "Pick image from device"  button full-widthWrapped the image…

### DIFF
--- a/lib/utilities/playlist_image_picker.dart
+++ b/lib/utilities/playlist_image_picker.dart
@@ -121,18 +121,22 @@ Widget buildImagePickerRow(
     child: OutlinedButton.icon(
       onPressed: onPickImage,
       style: OutlinedButton.styleFrom(
+        alignment: Alignment.centerLeft,
         foregroundColor: colorScheme.primary,
         side: BorderSide(
           color: isImagePicked ? colorScheme.primary : colorScheme.outline,
         ),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
       ),
-      icon: Icon(
-        isImagePicked
-            ? FluentIcons.checkmark_circle_20_filled
-            : FluentIcons.image_add_20_regular,
-        size: 20,
+      icon: Padding(
+        padding: const EdgeInsets.only(left: 4),
+        child: Icon(
+          isImagePicked
+              ? FluentIcons.checkmark_circle_20_filled
+              : FluentIcons.image_add_20_regular,
+          size: 20,
+        ),
       ),
       label: Text(
         isImagePicked

--- a/lib/utilities/playlist_image_picker.dart
+++ b/lib/utilities/playlist_image_picker.dart
@@ -116,26 +116,29 @@ Widget buildImagePickerRow(
 ) {
   final colorScheme = Theme.of(context).colorScheme;
 
-  return OutlinedButton.icon(
-    onPressed: onPickImage,
-    style: OutlinedButton.styleFrom(
-      foregroundColor: colorScheme.primary,
-      side: BorderSide(
-        color: isImagePicked ? colorScheme.primary : colorScheme.outline,
+  return SizedBox(
+    width: double.infinity,
+    child: OutlinedButton.icon(
+      onPressed: onPickImage,
+      style: OutlinedButton.styleFrom(
+        foregroundColor: colorScheme.primary,
+        side: BorderSide(
+          color: isImagePicked ? colorScheme.primary : colorScheme.outline,
+        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       ),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-    ),
-    icon: Icon(
-      isImagePicked
-          ? FluentIcons.checkmark_circle_20_filled
-          : FluentIcons.image_add_20_regular,
-      size: 20,
-    ),
-    label: Text(
-      isImagePicked
-          ? context.l10n!.imagePicked
-          : context.l10n!.pickImageFromDevice,
+      icon: Icon(
+        isImagePicked
+            ? FluentIcons.checkmark_circle_20_filled
+            : FluentIcons.image_add_20_regular,
+        size: 20,
+      ),
+      label: Text(
+        isImagePicked
+            ? context.l10n!.imagePicked
+            : context.l10n!.pickImageFromDevice,
+      ),
     ),
   );
 }


### PR DESCRIPTION
Aligned the playlist image picker button to match text field width.

Previously, the "Pick image from device" button would shrink to fit its label text, causing misalignment with the text fields above it in the playlist creation and edit dialogs. This was especially noticeable when using languages with shorter translations.

This fix wraps the button in a `SizedBox` with `width: double.infinity` to ensure consistent full-width alignment across all languages.

### Screenshots
**Before:**

![Antes](https://github.com/user-attachments/assets/80c6fc31-e103-4bc4-ac0d-cdd83828b016)


**After:**

![1000035190](https://github.com/user-attachments/assets/3737f3b3-0d32-4b97-8f6f-ea1e3648f598)

