### PR TITLE
fix(ui): prevent SnackBar from overlapping MiniPlayer

### DIFF
--- a/lib/utilities/flutter_toast.dart
+++ b/lib/utilities/flutter_toast.dart
@@ -21,6 +21,8 @@
 
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
+import 'package:musify/main.dart';
+import 'package:musify/widgets/mini_player.dart';
 
 void showToast(
   BuildContext context,
@@ -29,13 +31,15 @@ void showToast(
   IconData? icon,
 }) {
   final colorScheme = Theme.of(context).colorScheme;
+  final isMiniPlayerVisible = audioHandler.mediaItem.value != null;
+  final bottomMargin = 12.0 + (isMiniPlayerVisible ? MiniPlayer.playerHeight : 0.0);
 
   ScaffoldMessenger.of(context).showSnackBar(
     SnackBar(
       backgroundColor: colorScheme.secondaryContainer,
       behavior: SnackBarBehavior.floating,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      margin: EdgeInsets.fromLTRB(16, 12, 16, bottomMargin),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
       elevation: 6,
       content: Row(
@@ -71,13 +75,15 @@ void showToastWithButton(
   IconData? icon,
 }) {
   final colorScheme = Theme.of(context).colorScheme;
+  final isMiniPlayerVisible = audioHandler.mediaItem.value != null;
+  final bottomMargin = 12.0 + (isMiniPlayerVisible ? MiniPlayer.playerHeight : 0.0);
 
   ScaffoldMessenger.of(context).showSnackBar(
     SnackBar(
       backgroundColor: colorScheme.secondaryContainer,
       behavior: SnackBarBehavior.floating,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      margin: EdgeInsets.fromLTRB(16, 12, 16, bottomMargin),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       elevation: 6,
       content: Row(

--- a/lib/widgets/rename_song_dialog.dart
+++ b/lib/widgets/rename_song_dialog.dart
@@ -21,6 +21,8 @@
 
 import 'package:flutter/material.dart';
 import 'package:musify/extensions/l10n.dart';
+import 'package:musify/main.dart';
+import 'package:musify/widgets/mini_player.dart';
 
 class RenameSongDialog extends StatefulWidget {
   const RenameSongDialog({
@@ -61,8 +63,13 @@ class _RenameSongDialogState extends State<RenameSongDialog> {
     final newArtist = _artistController.text.trim();
 
     if (newTitle.isEmpty || newArtist.isEmpty) {
+      final isMiniPlayerVisible = audioHandler.mediaItem.value != null;
+      final bottomMargin = 12.0 + (isMiniPlayerVisible ? MiniPlayer.playerHeight : 0.0);
+
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
+          behavior: SnackBarBehavior.floating,
+          margin: EdgeInsets.fromLTRB(16, 12, 16, bottomMargin),
           content: Text(context.l10n!.fieldsNotEmpty),
           duration: const Duration(seconds: 2),
         ),


### PR DESCRIPTION
### Description

Fixed a UX issue where SnackBars appeared on top of the MiniPlayer, blocking playback controls until they dismissed.

**Root cause:** SnackBars were using a fixed bottom margin regardless of MiniPlayer visibility.

**Fix:** Bottom margin is now dynamically calculated based on whether a song is currently loaded (`audioHandler.mediaItem.value != null`). When the MiniPlayer is visible, `MiniPlayer.playerHeight` is added to the bottom margin, pushing the SnackBar above the playback controls.

### Changes

- **`lib/utilities/flutter_toast.dart`:** Updated `showToast()` and `showToastWithButton()` to dynamically calculate the bottom margin based on `audioHandler.mediaItem`
- **`lib/widgets/rename_song_dialog.dart`:** Applied the same fix to the validation error SnackBar in `RenameSongDialog`, ensuring consistency across all SnackBars in the app

### Before
![1000035194(1)](https://github.com/user-attachments/assets/1d81307c-4c34-479e-963d-906678dace76)

### After
![1000035198](https://github.com/user-attachments/assets/0c7326be-73f8-4b13-a2b5-33a66c8e05e7)


This is a pure UX bugfix with no logic changes.
