### PR TITLE
fix(ui): aliigment setSleepTimer text

### DIFF
--- a/lib/widgets/now_playing/bottom_actions_row.dart
+++ b/lib/widgets/now_playing/bottom_actions_row.dart
@@ -14,7 +14,6 @@
  *     You should have received a copy of the GNU General Public License
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
- *
  *     For more information about Musify, including how to contribute,
  *     please visit: https://github.com/gokadzev/Musify
  */
@@ -302,11 +301,13 @@ void _showSleepTimerDialog(BuildContext context) {
               children: [
                 Icon(FluentIcons.timer_24_regular, color: colorScheme.primary),
                 const SizedBox(width: 12),
-                Text(
-                  context.l10n!.setSleepTimer,
-                  style: TextStyle(
-                    color: colorScheme.onSurface,
-                    fontWeight: FontWeight.w600,
+                Expanded(
+                  child: Text(
+                    context.l10n!.setSleepTimer,
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
               ],
@@ -430,14 +431,17 @@ Widget _buildTimeSelector({
     child: Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text(
-          label,
-          style: TextStyle(
-            color: colorScheme.onSurface,
-            fontWeight: FontWeight.w500,
-            fontSize: 16,
+        Expanded(
+          child: Text(
+            label,
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.w500,
+              fontSize: 16,
+            ),
           ),
         ),
+        const SizedBox(width: 8),
         Row(
           children: [
             IconButton(


### PR DESCRIPTION
In some languages, the ‘Set Sleep Timer’ text was overflowing or going outside the container, so I fixed that. This was happening in several languages where the translation was longer.

**Before**
![1000035312](https://github.com/user-attachments/assets/a98d3028-0efa-429f-a798-ac3c73db4aa2)

**After**
![1000035311](https://github.com/user-attachments/assets/3e55e047-56f2-4b1d-9364-01154d4b3889)
