### PR TITLE
feat(player): hydrate standalone playback queue from YouTube Music

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -37,7 +37,7 @@ jobs:
       # Build universal apk.
       - run: flutter build apk --debug --flavor github
       # Upload universal generated apk to the artifacts.
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Musify-debug.apk
           path: build/app/outputs/flutter-apk/app-github-debug.apk

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -230,23 +230,6 @@ class SettingsPage extends StatelessWidget {
           },
         ),
         ValueListenableBuilder<bool>(
-          valueListenable: playNextSongAutomatically,
-          builder: (_, value, __) {
-            return CustomBar(
-              context.l10n!.automaticSongPicker,
-              FluentIcons.music_note_2_play_20_filled,
-              description: context.l10n!.automaticSongPickerDescription,
-              trailing: Switch(
-                value: value,
-                onChanged: (value) {
-                  audioHandler.changeAutoPlayNextStatus();
-                  showToast(context, context.l10n!.settingChangedMsg);
-                },
-              ),
-            );
-          },
-        ),
-        ValueListenableBuilder<bool>(
           valueListenable: externalRecommendations,
           builder: (_, value, __) {
             return CustomBar(

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -31,6 +31,7 @@ import 'package:musify/models/position_data.dart';
 import 'package:musify/services/common_services.dart';
 import 'package:musify/services/data_manager.dart';
 import 'package:musify/services/settings_manager.dart';
+import 'package:musify/services/ytmusic_queue_service.dart';
 import 'package:musify/utilities/mediaitem.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -71,6 +72,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
   Timer? _sleepTimer;
   Timer? _debounceTimer;
+  Timer? _queueJumpDebounceTimer;
   bool sleepTimerExpired = false;
 
   final List<Map> _queueList = [];
@@ -81,10 +83,11 @@ class MusifyAudioHandler extends BaseAudioHandler {
   int _currentQueueIndex = 0;
   int _currentLoadingIndex = -1;
   int _currentLoadingTransitionId = -1;
+  int? _pendingQueuePlaybackIndex;
+  int _activeTransitionId = 0;
   bool _isUpdatingState = false;
   int _songTransitionCounter = 0;
   bool _completionEventPending = false;
-  bool _completionHandlerLoadStarted = false;
 
   String? _lastError;
   int _consecutiveErrors = 0;
@@ -92,14 +95,23 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
   static const int _maxHistorySize = 50;
   static const int _queueLookahead = 3;
+  static const int _queueHydrationThreshold = 2;
+  static const int _preferredFreshQueueAppendCount = 15;
+  static const int _maxQueueHydrationPages = 3;
   static const int _maxConcurrentPreloads = 2;
   static const Duration _errorRetryDelay = Duration(seconds: 2);
   static const Duration _songTransitionTimeout = Duration(seconds: 30);
   static const Duration _debounceInterval = Duration(milliseconds: 150);
+  static const Duration _queueJumpDebounceInterval = Duration(
+    milliseconds: 120,
+  );
 
   int _activePreloadCount = 0;
   final Set<String> _preloadingYtIds = <String>{};
   final Set<String> _preloadedYtIds = <String>{};
+  bool _queueHydrationInProgress = false;
+  String? _lastQueueHydrationKey;
+  String? _ytQueueContinuationToken;
 
   Stream<PositionData> get positionDataStream =>
       Rx.combineLatest3<Duration, Duration, Duration?, PositionData>(
@@ -546,7 +558,6 @@ class MusifyAudioHandler extends BaseAudioHandler {
               // Only reset if still marked as pending (another event didn't override)
               if (_completionEventPending) {
                 _completionEventPending = false;
-                _completionHandlerLoadStarted = false;
               }
               // else {
               //   logger.log(
@@ -560,7 +571,6 @@ class MusifyAudioHandler extends BaseAudioHandler {
         }
       } else if (state == ProcessingState.ready) {
         _completionEventPending = false;
-        _completionHandlerLoadStarted = false;
       }
     } catch (e, stackTrace) {
       logger.log(
@@ -586,8 +596,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
     if (hasNext ||
         (repeatNotifier.value == AudioServiceRepeatMode.all &&
-            _queueList.isNotEmpty) ||
-        playNextSongAutomatically.value) {
+            _queueList.isNotEmpty)) {
       Future.delayed(_errorRetryDelay, skipToNext);
     }
   }
@@ -613,100 +622,6 @@ class MusifyAudioHandler extends BaseAudioHandler {
         stackTrace: stackTrace,
       );
     }
-  }
-
-  Future<void> _playNextRecommendedSong() async {
-    if (_currentLoadingIndex >= 0) {
-      logger.log(
-        'Already loading next song (index: $_currentLoadingIndex), skipping',
-      );
-      return;
-    }
-
-    try {
-      final baseSong = _getCurrentSongForRecommendations();
-      if (baseSong == null) {
-        logger.log('No valid song for recommendations');
-        return;
-      }
-
-      if (nextRecommendedSong == null) {
-        await _fetchRecommendedSong(baseSong);
-      }
-
-      if (nextRecommendedSong != null) {
-        await _playRecommendation();
-      } else {
-        logger.log('No recommendations available for "${baseSong['title']}"');
-      }
-    } catch (e, stackTrace) {
-      logger.log(
-        'Error playing recommended song',
-        error: e,
-        stackTrace: stackTrace,
-      );
-    }
-  }
-
-  Map? _getCurrentSongForRecommendations() {
-    final currentMediaItem = mediaItem.valueOrNull;
-
-    if (currentMediaItem == null || currentMediaItem.id.isEmpty) {
-      logger.log('No current media item available');
-      return null;
-    }
-
-    return mediaItemToMap(currentMediaItem);
-  }
-
-  Future<void> _fetchRecommendedSong(Map baseSong) async {
-    try {
-      await getSimilarSong(baseSong['ytid']).timeout(
-        const Duration(seconds: 7),
-        onTimeout: () {
-          logger.log('Recommendation fetch timed out');
-        },
-      );
-    } catch (e, stackTrace) {
-      logger.log(
-        'Error fetching recommendation',
-        error: e,
-        stackTrace: stackTrace,
-      );
-    }
-  }
-
-  Future<void> _playRecommendation() async {
-    if (nextRecommendedSong == null) return;
-
-    final recommendedSong = nextRecommendedSong;
-    nextRecommendedSong = null;
-
-    await addToQueue(recommendedSong);
-    await _playFromQueue(_queueList.length - 1);
-  }
-
-  void _prefetchNextRecommendation(String currentSongYtid) {
-    if (nextRecommendedSong != null) {
-      return;
-    }
-
-    Future.microtask(() async {
-      try {
-        await getSimilarSong(currentSongYtid).timeout(
-          const Duration(seconds: 5),
-          onTimeout: () {
-            logger.log('Prefetch recommendation timed out');
-          },
-        );
-      } catch (e, stackTrace) {
-        logger.log(
-          'Error prefetching recommendation',
-          error: e,
-          stackTrace: stackTrace,
-        );
-      }
-    });
   }
 
   void _addToHistory(Map song) {
@@ -807,6 +722,8 @@ class MusifyAudioHandler extends BaseAudioHandler {
       if (replace) {
         _queueList.clear();
         _originalQueueList.clear();
+        _lastQueueHydrationKey = null;
+        _ytQueueContinuationToken = null;
         _currentQueueIndex = 0;
         _currentLoadingIndex = -1;
         _currentLoadingTransitionId = -1;
@@ -913,9 +830,14 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
   void clearQueue() {
     try {
+      _queueJumpDebounceTimer?.cancel();
+      _pendingQueuePlaybackIndex = null;
       _queueList.clear();
       _originalQueueList.clear();
+      _lastQueueHydrationKey = null;
+      _ytQueueContinuationToken = null;
       _currentQueueIndex = 0;
+      _activeTransitionId = -1;
       _currentLoadingIndex = -1;
       _currentLoadingTransitionId = -1;
       _resetPreloadingState();
@@ -946,6 +868,155 @@ class MusifyAudioHandler extends BaseAudioHandler {
         error: e,
         stackTrace: stackTrace,
       );
+    }
+  }
+
+  void _scheduleQueueHydrationWithPriority({required bool force}) {
+    Future.microtask(() async {
+      try {
+        await _hydrateQueueFromYouTube(force: force);
+      } catch (e, stackTrace) {
+        logger.log(
+          'Error scheduling queue hydration',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+    });
+  }
+
+  Future<bool> _hydrateQueueFromYouTube({bool force = false}) async {
+    if (_queueHydrationInProgress || _queueList.isEmpty) {
+      return false;
+    }
+
+    if (!force) {
+      final remainingTracks = _queueList.length - _currentQueueIndex - 1;
+      if (remainingTracks >= _queueHydrationThreshold) {
+        return false;
+      }
+    }
+
+    final seedSong = currentSong;
+    final seedYtid = seedSong?['ytid']?.toString() ?? '';
+    if (seedSong == null || seedYtid.isEmpty) {
+      return false;
+    }
+
+    final playlistId = seedSong['queuePlaylistId']?.toString();
+    final params = seedSong['queueParams']?.toString();
+    final hydrationKey =
+        '$seedYtid|${playlistId ?? ''}|${params ?? ''}|$_currentQueueIndex|${_queueList.length}';
+
+    if (!force && _lastQueueHydrationKey == hydrationKey) {
+      return false;
+    }
+
+    _queueHydrationInProgress = true;
+
+    try {
+      final existingIds = _queueList
+          .map((song) => song['ytid']?.toString())
+          .whereType<String>()
+          .toSet();
+      final appendedSongs = <Map>[];
+      final isAtQueueEnd = _currentQueueIndex >= _queueList.length - 1;
+      final shouldSeedFreshQueue =
+          force || _queueList.length <= 1 || isAtQueueEnd;
+      var nextContinuationToken = shouldSeedFreshQueue
+          ? null
+          : _ytQueueContinuationToken;
+
+      var pagesFetched = 0;
+      while (pagesFetched < _maxQueueHydrationPages) {
+        final result = await YtMusicQueueService().fetchQueue(
+          seedYtid,
+          playlistId: playlistId,
+          params: params,
+          continuationToken: nextContinuationToken,
+        );
+        pagesFetched++;
+
+        if (result == null || result.tracks.isEmpty) {
+          if (nextContinuationToken != null &&
+              nextContinuationToken.isNotEmpty) {
+            nextContinuationToken = null;
+            continue;
+          }
+          break;
+        }
+
+        _ytQueueContinuationToken = result.continuationToken;
+        final resolvedPlaylistId = result.playlistId;
+        final resolvedParams = result.params;
+
+        for (final track in result.tracks) {
+          if (track.ytid == seedYtid || existingIds.contains(track.ytid)) {
+            continue;
+          }
+
+          final song = track.toSongMap()
+            ..putIfAbsent('queuePlaylistId', () => resolvedPlaylistId)
+            ..putIfAbsent('queueParams', () => resolvedParams);
+
+          appendedSongs.add(song);
+          existingIds.add(track.ytid);
+        }
+
+        if (!shouldSeedFreshQueue ||
+            appendedSongs.length >= _preferredFreshQueueAppendCount ||
+            result.continuationToken == null ||
+            result.continuationToken!.isEmpty) {
+          break;
+        }
+
+        nextContinuationToken = result.continuationToken;
+      }
+
+      if (appendedSongs.isEmpty) {
+        final fallbackSongs = await fetchRelatedSongsQueue(
+          seedYtid,
+          limit: _preferredFreshQueueAppendCount,
+        );
+        for (final song in fallbackSongs) {
+          final fallbackYtid = song['ytid']?.toString();
+          if (fallbackYtid == null ||
+              fallbackYtid.isEmpty ||
+              fallbackYtid == seedYtid ||
+              existingIds.contains(fallbackYtid)) {
+            continue;
+          }
+
+          appendedSongs.add(song);
+          existingIds.add(fallbackYtid);
+        }
+      }
+
+      if (appendedSongs.isEmpty) {
+        return false;
+      }
+
+      _queueList.addAll(appendedSongs);
+      _lastQueueHydrationKey = hydrationKey;
+      if (shuffleNotifier.value && _originalQueueList.isNotEmpty) {
+        _originalQueueList.addAll(appendedSongs);
+      }
+      _updateQueueMediaItems();
+      _cleanupOldPreloadedSongs();
+      _preloadUpcomingSongs();
+      return true;
+    } catch (e, stackTrace) {
+      logger.log(
+        'Error hydrating queue from YouTube Music',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      if (_lastQueueHydrationKey == hydrationKey) {
+        _lastQueueHydrationKey = null;
+      }
+      return false;
+    } finally {
+      _queueHydrationInProgress = false;
     }
   }
 
@@ -999,36 +1070,17 @@ class MusifyAudioHandler extends BaseAudioHandler {
   }
 
   Future<void> _playFromQueue(int index) async {
+    var currentTransitionId = -1;
     try {
-      // logger.log(
-      //   '[PLAY_FROM_QUEUE] Called with index=$index, _currentLoadingIndex=$_currentLoadingIndex',
-      //   null,
-      //   null,
-      // );
       if (index < 0 || index >= _queueList.length) {
         logger.log('Invalid queue index: $index');
         return;
       }
 
-      // If already loading any song, skip the request
-      // UNLESS we're in the middle of handling a completion event (allow one load attempt)
-      if (_currentLoadingIndex >= 0 && !_completionEventPending) {
-        return;
-      }
-
-      if (_currentLoadingIndex >= 0 &&
-          _completionEventPending &&
-          !_completionHandlerLoadStarted) {
-        _completionHandlerLoadStarted = true;
-      } else if (_currentLoadingIndex >= 0 &&
-          _completionEventPending &&
-          _completionHandlerLoadStarted) {
-        return;
-      }
-
       // Start new transition
       _songTransitionCounter++;
-      final currentTransitionId = _songTransitionCounter;
+      currentTransitionId = _songTransitionCounter;
+      _activeTransitionId = currentTransitionId;
       _currentLoadingIndex = index;
       _currentLoadingTransitionId = currentTransitionId;
 
@@ -1042,6 +1094,9 @@ class MusifyAudioHandler extends BaseAudioHandler {
       );
       final uniqueId = currentMediaItem.id;
 
+      _completionEventPending = false;
+      await audioPlayer.stop();
+
       await Future.microtask(() {
         mediaItem.add(currentMediaItem);
       });
@@ -1051,7 +1106,11 @@ class MusifyAudioHandler extends BaseAudioHandler {
         mediaId: uniqueId,
       );
 
-      final success = await playSong(_queueList[index], mediaId: uniqueId);
+      final success = await playSong(
+        _queueList[index],
+        mediaId: uniqueId,
+        transitionId: currentTransitionId,
+      );
 
       // Only process result if this is still the current transition
       if (currentTransitionId == _currentLoadingTransitionId) {
@@ -1067,8 +1126,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
       logger.log('Error playing from queue', error: e, stackTrace: stackTrace);
       _handlePlaybackError();
     } finally {
-      // Only reset if we haven't already cleared it in the success path
-      if (_currentLoadingIndex >= 0) {
+      if (currentTransitionId == _currentLoadingTransitionId) {
         _currentLoadingIndex = -1;
         _currentLoadingTransitionId = -1;
       }
@@ -1203,7 +1261,10 @@ class MusifyAudioHandler extends BaseAudioHandler {
   @override
   Future<void> stop() async {
     _debounceTimer?.cancel();
+    _queueJumpDebounceTimer?.cancel();
+    _pendingQueuePlaybackIndex = null;
     _completionEventPending = false;
+    _activeTransitionId = -1;
     _currentLoadingIndex = -1;
     _currentLoadingTransitionId = -1;
     try {
@@ -1240,7 +1301,57 @@ class MusifyAudioHandler extends BaseAudioHandler {
   Future<void> rewind() =>
       seek(Duration(seconds: audioPlayer.position.inSeconds - 15));
 
-  Future<bool> playSong(Map song, {String? mediaId}) async {
+  bool _isActiveTransition(int transitionId) =>
+      transitionId == _activeTransitionId &&
+      transitionId == _currentLoadingTransitionId;
+
+  void _requestQueuePlayback(int index, {bool immediate = false}) {
+    _queueJumpDebounceTimer?.cancel();
+    _pendingQueuePlaybackIndex = index;
+    _previewQueueSelection(index);
+
+    if (immediate) {
+      _pendingQueuePlaybackIndex = null;
+      unawaited(_playFromQueue(index));
+      return;
+    }
+
+    _queueJumpDebounceTimer = Timer(_queueJumpDebounceInterval, () {
+      _queueJumpDebounceTimer = null;
+      final targetIndex = _pendingQueuePlaybackIndex;
+      _pendingQueuePlaybackIndex = null;
+      if (targetIndex != null) {
+        unawaited(_playFromQueue(targetIndex));
+      }
+    });
+  }
+
+  void _previewQueueSelection(int index) {
+    if (index < 0 || index >= _queueList.length) {
+      return;
+    }
+
+    _currentQueueIndex = index;
+    final currentMediaItem = _getMediaItemForQueue(_queueList[index], index);
+    mediaItem.add(currentMediaItem);
+    _emitOptimisticLoadingState(
+      queueIndex: index,
+      mediaId: currentMediaItem.id,
+    );
+    if (audioPlayer.playing || _currentLoadingIndex >= 0) {
+      unawaited(audioPlayer.stop());
+    }
+  }
+
+  Future<void> playSingleSong(Map song) async {
+    await addPlaylistToQueue([song], replace: true);
+  }
+
+  Future<bool> playSong(
+    Map song, {
+    String? mediaId,
+    required int transitionId,
+  }) async {
     try {
       if (song['ytid'] == null || song['ytid'].toString().isEmpty) {
         logger.log('Invalid song data: missing ytid');
@@ -1279,7 +1390,14 @@ class MusifyAudioHandler extends BaseAudioHandler {
         mediaId: mediaId,
       );
 
+      if (!_isActiveTransition(transitionId)) {
+        return false;
+      }
+
       var songUrl = await _getSongUrl(song, isOffline);
+      if (!_isActiveTransition(transitionId)) {
+        return false;
+      }
 
       // If offline file is missing, try falling back to online
       if ((songUrl == null || songUrl.isEmpty) && isOffline) {
@@ -1288,6 +1406,9 @@ class MusifyAudioHandler extends BaseAudioHandler {
         );
         isOffline = false;
         songUrl = await _getSongUrl(song, isOffline);
+        if (!_isActiveTransition(transitionId)) {
+          return false;
+        }
       }
 
       if (songUrl == null || songUrl.isEmpty) {
@@ -1297,6 +1418,9 @@ class MusifyAudioHandler extends BaseAudioHandler {
       }
 
       final audioSource = await buildAudioSource(song, songUrl, isOffline);
+      if (!_isActiveTransition(transitionId)) {
+        return false;
+      }
       if (audioSource == null) {
         logger.log('Failed to build audio source for ${song['ytid']}');
         _lastError = 'Failed to build audio source';
@@ -1309,6 +1433,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
         songUrl,
         isOffline,
         mediaId: mediaId,
+        transitionId: transitionId,
       );
     } catch (e, stackTrace) {
       logger.log('Error playing song', error: e, stackTrace: stackTrace);
@@ -1362,14 +1487,28 @@ class MusifyAudioHandler extends BaseAudioHandler {
     String songUrl,
     bool isOffline, {
     String? mediaId,
+    required int transitionId,
     bool allowOnlineRetry = true,
   }) async {
     try {
+      if (!_isActiveTransition(transitionId)) {
+        return false;
+      }
+
       await audioPlayer
           .setAudioSource(audioSource)
           .timeout(_songTransitionTimeout);
+      if (!_isActiveTransition(transitionId)) {
+        await audioPlayer.stop();
+        return false;
+      }
+
       unawaited(_ensureEqualizerConfigured(force: true));
       await Future.delayed(const Duration(milliseconds: 100));
+      if (!_isActiveTransition(transitionId)) {
+        await audioPlayer.stop();
+        return false;
+      }
 
       if (audioPlayer.duration != null) {
         var currentMediaItem = mapToMediaItem(song);
@@ -1381,6 +1520,15 @@ class MusifyAudioHandler extends BaseAudioHandler {
         );
       }
 
+      if (!_isActiveTransition(transitionId)) {
+        await audioPlayer.stop();
+        return false;
+      }
+
+      final shouldRefreshQueueNow =
+          _queueList.length <= 1 || _currentQueueIndex >= _queueList.length - 1;
+      _scheduleQueueHydrationWithPriority(force: shouldRefreshQueueNow);
+
       await audioPlayer.play();
 
       if (!isOffline) {
@@ -1390,11 +1538,6 @@ class MusifyAudioHandler extends BaseAudioHandler {
       }
 
       _updatePlaybackState();
-
-      if (playNextSongAutomatically.value) {
-        _prefetchNextRecommendation(song['ytid']);
-      }
-
       Future.delayed(const Duration(seconds: 2), _preloadUpcomingSongs);
 
       return true;
@@ -1406,7 +1549,11 @@ class MusifyAudioHandler extends BaseAudioHandler {
       );
 
       if (isOffline) {
-        return _attemptOfflineFallback(song, mediaId: mediaId);
+        return _attemptOfflineFallback(
+          song,
+          mediaId: mediaId,
+          transitionId: transitionId,
+        );
       }
 
       if (allowOnlineRetry) {
@@ -1434,6 +1581,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
                 refreshedUrl,
                 false,
                 mediaId: mediaId,
+                transitionId: transitionId,
                 allowOnlineRetry: false,
               );
             }
@@ -1446,13 +1594,23 @@ class MusifyAudioHandler extends BaseAudioHandler {
     }
   }
 
-  Future<bool> _attemptOfflineFallback(Map song, {String? mediaId}) async {
+  Future<bool> _attemptOfflineFallback(
+    Map song, {
+    String? mediaId,
+    required int transitionId,
+  }) async {
     final onlineUrl = await fetchSongStreamUrl(
       song['ytid'],
       song['isLive'] ?? false,
     );
+    if (!_isActiveTransition(transitionId)) {
+      return false;
+    }
     if (onlineUrl != null && onlineUrl.isNotEmpty) {
       final onlineSource = await buildAudioSource(song, onlineUrl, false);
+      if (!_isActiveTransition(transitionId)) {
+        return false;
+      }
       if (onlineSource != null) {
         return _setAudioSourceAndPlay(
           song,
@@ -1460,6 +1618,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
           onlineUrl,
           false,
           mediaId: mediaId,
+          transitionId: transitionId,
         );
       }
     }
@@ -1587,7 +1746,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
         logger.log('Invalid song index: $newIndex');
         return;
       }
-      await _playFromQueue(newIndex);
+      _requestQueuePlayback(newIndex);
     } catch (e, stackTrace) {
       logger.log('Error skipping to song', error: e, stackTrace: stackTrace);
     }
@@ -1596,14 +1755,21 @@ class MusifyAudioHandler extends BaseAudioHandler {
   @override
   Future<void> skipToNext() async {
     try {
-      if (_currentQueueIndex < _queueList.length - 1) {
-        await _playFromQueue(_currentQueueIndex + 1);
+      final baseIndex =
+          _pendingQueuePlaybackIndex ??
+          (_currentLoadingIndex >= 0
+              ? _currentLoadingIndex
+              : _currentQueueIndex);
+      if (baseIndex < _queueList.length - 1) {
+        _requestQueuePlayback(baseIndex + 1);
       } else if (repeatNotifier.value == AudioServiceRepeatMode.all &&
           _queueList.isNotEmpty) {
-        await _playFromQueue(0);
-      } else if (playNextSongAutomatically.value &&
-          _currentLoadingIndex == -1) {
-        await _playNextRecommendedSong();
+        _requestQueuePlayback(0, immediate: true);
+      } else if (_currentLoadingIndex == -1) {
+        final extendedQueue = await _hydrateQueueFromYouTube(force: true);
+        if (extendedQueue && _currentQueueIndex < _queueList.length - 1) {
+          _requestQueuePlayback(_currentQueueIndex + 1, immediate: true);
+        }
       }
 
       _cleanupOldPreloadedSongs();
@@ -1619,14 +1785,19 @@ class MusifyAudioHandler extends BaseAudioHandler {
   @override
   Future<void> skipToPrevious() async {
     try {
-      if (_currentQueueIndex > 0) {
-        await _playFromQueue(_currentQueueIndex - 1);
+      final baseIndex =
+          _pendingQueuePlaybackIndex ??
+          (_currentLoadingIndex >= 0
+              ? _currentLoadingIndex
+              : _currentQueueIndex);
+      if (baseIndex > 0) {
+        _requestQueuePlayback(baseIndex - 1);
       } else if (_historyList.isNotEmpty) {
         final lastSong = _historyList.removeLast();
         _queueList.insert(0, lastSong);
         _currentQueueIndex = 0;
         _updateQueueMediaItems();
-        await _playFromQueue(0);
+        _requestQueuePlayback(0, immediate: true);
       }
 
       _cleanupOldPreloadedSongs();
@@ -1765,17 +1936,6 @@ class MusifyAudioHandler extends BaseAudioHandler {
         'settings',
         'sponsorBlockSupport',
         sponsorBlockSupport.value,
-      ),
-    );
-  }
-
-  void changeAutoPlayNextStatus() {
-    playNextSongAutomatically.value = !playNextSongAutomatically.value;
-    unawaited(
-      addOrUpdateData(
-        'settings',
-        'playNextSongAutomatically',
-        playNextSongAutomatically.value,
       ),
     );
   }

--- a/lib/services/common_services.dart
+++ b/lib/services/common_services.dart
@@ -49,8 +49,6 @@ List userOfflineSongs = Hive.box(
   'userNoBackup',
 ).get('offlineSongs', defaultValue: []);
 
-dynamic nextRecommendedSong;
-
 final currentLikedSongsLength = ValueNotifier<int>(userLikedSongsList.length);
 final currentOfflineSongsLength = ValueNotifier<int>(userOfflineSongs.length);
 final currentRecentlyPlayedLength = ValueNotifier<int>(
@@ -134,6 +132,33 @@ Future<List> fetchSongsList(String searchQuery) async {
   } catch (e, stackTrace) {
     logger.log('Error in fetchSongsList', error: e, stackTrace: stackTrace);
     return [];
+  }
+}
+
+Future<List<Map<String, dynamic>>> fetchRelatedSongsQueue(
+  String songYtId, {
+  int limit = 20,
+}) async {
+  try {
+    if (songYtId.isEmpty) {
+      return <Map<String, dynamic>>[];
+    }
+
+    final song = await ytClient.videos.get(songYtId);
+    final relatedSongs = await ytClient.videos.getRelatedVideos(song) ?? [];
+
+    return relatedSongs
+        .take(limit)
+        .map((relatedSong) => returnSongLayout(0, relatedSong))
+        .cast<Map<String, dynamic>>()
+        .toList();
+  } catch (e, stackTrace) {
+    logger.log(
+      'Error fetching related songs queue for $songYtId',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return <Map<String, dynamic>>[];
   }
 }
 
@@ -370,25 +395,6 @@ Future<List<Map<String, int>>> getSkipSegments(String id) async {
   } catch (e, stackTrace) {
     logger.log('Error in getSkipSegments', error: e, stackTrace: stackTrace);
     return [];
-  }
-}
-
-Future<void> getSimilarSong(String songYtId) async {
-  try {
-    final song = await ytClient.videos.get(songYtId);
-    final relatedSongs = await ytClient.videos.getRelatedVideos(song) ?? [];
-
-    if (relatedSongs.isNotEmpty) {
-      nextRecommendedSong = returnSongLayout(0, relatedSongs[0]);
-    } else {
-      logger.log('No related songs found for $songYtId');
-    }
-  } catch (e, stackTrace) {
-    logger.log(
-      'Error while fetching next similar song:',
-      error: e,
-      stackTrace: stackTrace,
-    );
   }
 }
 

--- a/lib/services/settings_manager.dart
+++ b/lib/services/settings_manager.dart
@@ -32,10 +32,6 @@ final shouldWeCheckUpdates = ValueNotifier<bool?>(
   Hive.box('settings').get('shouldWeCheckUpdates', defaultValue: null),
 );
 
-final playNextSongAutomatically = ValueNotifier<bool>(
-  Hive.box('settings').get('playNextSongAutomatically', defaultValue: false),
-);
-
 final useSystemColor = ValueNotifier<bool>(
   Hive.box('settings').get('useSystemColor', defaultValue: true),
 );

--- a/lib/services/ytmusic_queue_service.dart
+++ b/lib/services/ytmusic_queue_service.dart
@@ -1,0 +1,603 @@
+/*
+ *     Copyright (C) 2026 Valeri Gokadze
+ *
+ *     Musify is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     Musify is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ *     For more information about Musify, including how to contribute,
+ *     please visit: https://github.com/gokadzev/Musify
+ */
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:musify/main.dart';
+
+class YtMusicQueueTrack {
+  const YtMusicQueueTrack({
+    required this.ytid,
+    required this.title,
+    required this.artist,
+    required this.image,
+    this.duration,
+    this.queuePlaylistId,
+    this.queueParams,
+  });
+
+  final String ytid;
+  final String title;
+  final String artist;
+  final String image;
+  final int? duration;
+  final String? queuePlaylistId;
+  final String? queueParams;
+
+  Map<String, dynamic> toSongMap() {
+    return {
+      'ytid': ytid,
+      'title': title,
+      'artist': artist,
+      'image': image,
+      'lowResImage': image,
+      'highResImage': image,
+      'duration': duration,
+      'isLive': false,
+      if (queuePlaylistId != null) 'queuePlaylistId': queuePlaylistId,
+      if (queueParams != null) 'queueParams': queueParams,
+    };
+  }
+}
+
+class YtMusicQueueResult {
+  const YtMusicQueueResult({
+    required this.tracks,
+    this.playlistId,
+    this.params,
+    this.continuationToken,
+  });
+
+  final List<YtMusicQueueTrack> tracks;
+  final String? playlistId;
+  final String? params;
+  final String? continuationToken;
+}
+
+class YtMusicQueueService {
+  factory YtMusicQueueService() => _instance;
+
+  YtMusicQueueService._internal();
+
+  static final YtMusicQueueService _instance = YtMusicQueueService._internal();
+  static final Uri _homeUri = Uri.parse('https://music.youtube.com/');
+  static final Uri _nextUri = Uri.parse(
+    'https://music.youtube.com/youtubei/v1/next?prettyPrint=false',
+  );
+
+  static const String _defaultClientVersion = '1.20260128.03.00';
+  static const String _userAgent =
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 '
+      '(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+  static const Duration _requestTimeout = Duration(seconds: 8);
+  static const Duration _contextCacheTtl = Duration(hours: 6);
+
+  String _clientVersion = _defaultClientVersion;
+  String? _visitorData;
+  DateTime _contextFetchedAt = DateTime.fromMillisecondsSinceEpoch(0);
+
+  Future<YtMusicQueueResult?> fetchQueue(
+    String videoId, {
+    String? playlistId,
+    String? params,
+    String? continuationToken,
+  }) async {
+    if (videoId.isEmpty) {
+      return null;
+    }
+
+    try {
+      await _ensureClientContext();
+
+      final response = await _sendQueueRequest(
+        videoId,
+        playlistId: playlistId,
+        params: params,
+        continuationToken: continuationToken,
+      );
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        logger.log(
+          'YouTube Music queue request failed with status ${response.statusCode}',
+        );
+        return null;
+      }
+
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, dynamic>) {
+        logger.log('Unexpected YouTube Music queue payload shape');
+        return null;
+      }
+
+      final tracks = _parseQueueTracks(decoded);
+      if (tracks.isEmpty) {
+        return null;
+      }
+
+      final resolvedPlaylistId = tracks
+          .map((track) => track.queuePlaylistId)
+          .whereType<String>()
+          .firstWhere(
+            (value) => value.isNotEmpty,
+            orElse: () => playlistId ?? 'RDAMVM$videoId',
+          );
+      final resolvedParams = tracks
+          .map((track) => track.queueParams)
+          .whereType<String>()
+          .firstWhere((value) => value.isNotEmpty, orElse: () => params ?? '');
+
+      return YtMusicQueueResult(
+        tracks: tracks,
+        playlistId: resolvedPlaylistId,
+        params: resolvedParams.isEmpty ? null : resolvedParams,
+        continuationToken: _extractContinuationToken(decoded),
+      );
+    } catch (e, stackTrace) {
+      logger.log(
+        'Failed to fetch YouTube Music queue',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+  }
+
+  Future<http.Response> _sendQueueRequest(
+    String videoId, {
+    String? playlistId,
+    String? params,
+    String? continuationToken,
+  }) {
+    final endpoint = continuationToken == null
+        ? _nextUri
+        : _nextUri.replace(
+            queryParameters: {
+              'prettyPrint': 'false',
+              'ctoken': continuationToken,
+              'continuation': continuationToken,
+            },
+          );
+
+    return http
+        .post(
+          endpoint,
+          headers: {
+            'Accept': '*/*',
+            'Content-Type': 'application/json',
+            'Origin': 'https://music.youtube.com',
+            'Referer': 'https://music.youtube.com/watch?v=$videoId',
+            'User-Agent': _userAgent,
+            'X-Youtube-Client-Name': '67',
+            'X-Youtube-Client-Version': _clientVersion,
+            if (_visitorData != null && _visitorData!.isNotEmpty)
+              'X-Goog-Visitor-Id': _visitorData!,
+          },
+          body: jsonEncode({
+            'context': {
+              'client': {
+                'hl': 'en',
+                'gl': 'US',
+                'clientName': 'WEB_REMIX',
+                'clientVersion': _clientVersion,
+                'platform': 'DESKTOP',
+                'userAgent': _userAgent,
+              },
+              'user': {'lockedSafetyMode': false},
+              'request': {
+                'useSsl': true,
+                'internalExperimentFlags': <dynamic>[],
+                'consistencyTokenJars': <dynamic>[],
+              },
+            },
+            if (continuationToken == null) ...{
+              'videoId': videoId,
+              'playlistId': playlistId ?? 'RDAMVM$videoId',
+              if (params != null && params.isNotEmpty) 'params': params,
+              'isAudioOnly': true,
+              'enablePersistentPlaylistPanel': true,
+            } else
+              'continuation': continuationToken,
+          }),
+        )
+        .timeout(_requestTimeout);
+  }
+
+  Future<void> _ensureClientContext() async {
+    final now = DateTime.now();
+    if (now.difference(_contextFetchedAt) < _contextCacheTtl) {
+      return;
+    }
+
+    try {
+      final response = await http
+          .get(_homeUri, headers: {'User-Agent': _userAgent})
+          .timeout(_requestTimeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        return;
+      }
+
+      final body = response.body;
+      final clientVersionMatch = RegExp(
+        '"INNERTUBE_CLIENT_VERSION":"([^"]+)"',
+      ).firstMatch(body);
+      final visitorMatch = RegExp('"VISITOR_DATA":"([^"]+)"').firstMatch(body);
+
+      _clientVersion = clientVersionMatch?.group(1) ?? _defaultClientVersion;
+      _visitorData = visitorMatch?.group(1);
+      _contextFetchedAt = now;
+    } catch (e, stackTrace) {
+      logger.log(
+        'Failed to refresh YouTube Music client context',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      _clientVersion = _defaultClientVersion;
+      _visitorData = null;
+      _contextFetchedAt = now;
+    }
+  }
+
+  List<YtMusicQueueTrack> _parseQueueTracks(Map<String, dynamic> response) {
+    final directPanelItems = _extractDirectPanelItems(response);
+    final candidateRenderers = directPanelItems.isNotEmpty
+        ? directPanelItems
+              .map((entry) => entry['playlistPanelVideoRenderer'])
+              .whereType<Map<String, dynamic>>()
+              .toList()
+        : _collectPlaylistPanelRenderers(response);
+
+    final seen = <String>{};
+    final tracks = <YtMusicQueueTrack>[];
+
+    for (final renderer in candidateRenderers) {
+      final track = _mapRendererToTrack(renderer);
+      if (track == null || !seen.add(track.ytid)) {
+        continue;
+      }
+      tracks.add(track);
+    }
+
+    return tracks;
+  }
+
+  List<Map<String, dynamic>> _extractDirectPanelItems(
+    Map<String, dynamic> response,
+  ) {
+    final tabs = _readNested(response, [
+      'contents',
+      'singleColumnMusicWatchNextResultsRenderer',
+      'tabbedRenderer',
+      'watchNextTabbedResultsRenderer',
+      'tabs',
+    ]);
+
+    if (tabs is! List) {
+      return const [];
+    }
+
+    final items = <Map<String, dynamic>>[];
+
+    for (final tab in tabs) {
+      if (tab is! Map) continue;
+      final tabContent = _readNested(tab, ['tabRenderer', 'content']);
+      final contents =
+          _readNested(tabContent, [
+            'musicQueueRenderer',
+            'content',
+            'playlistPanelRenderer',
+            'contents',
+          ]) ??
+          _readNested(tabContent, ['playlistPanelRenderer', 'contents']);
+
+      if (contents is List) {
+        for (final item in contents) {
+          if (item is Map<String, dynamic>) {
+            items.add(item);
+          }
+        }
+      }
+    }
+
+    final fallback =
+        _readNested(response, [
+          'contents',
+          'singleColumnMusicWatchNextResultsRenderer',
+          'playlist',
+          'playlistPanelRenderer',
+          'contents',
+        ]) ??
+        _readNested(response, [
+          'contents',
+          'twoColumnWatchNextResults',
+          'playlist',
+          'playlist',
+          'contents',
+        ]);
+
+    if (items.isEmpty && fallback is List) {
+      for (final item in fallback) {
+        if (item is Map<String, dynamic>) {
+          items.add(item);
+        }
+      }
+    }
+
+    return items;
+  }
+
+  List<Map<String, dynamic>> _collectPlaylistPanelRenderers(
+    dynamic node, {
+    int depth = 0,
+    List<Map<String, dynamic>>? acc,
+  }) {
+    final result = acc ?? <Map<String, dynamic>>[];
+    if (node == null || depth > 12) {
+      return result;
+    }
+
+    if (node is List) {
+      for (final item in node) {
+        _collectPlaylistPanelRenderers(item, depth: depth + 1, acc: result);
+      }
+      return result;
+    }
+
+    if (node is! Map) {
+      return result;
+    }
+
+    final renderer = node['playlistPanelVideoRenderer'];
+    if (renderer is Map<String, dynamic>) {
+      result.add(renderer);
+    }
+
+    for (final value in node.values) {
+      _collectPlaylistPanelRenderers(value, depth: depth + 1, acc: result);
+    }
+
+    return result;
+  }
+
+  YtMusicQueueTrack? _mapRendererToTrack(Map<String, dynamic> renderer) {
+    final videoId = renderer['videoId']?.toString() ?? '';
+    if (videoId.isEmpty) {
+      return null;
+    }
+
+    final title =
+        _readNested(renderer, ['title', 'simpleText'])?.toString() ??
+        _joinRuns(_readNested(renderer, ['title', 'runs'])) ??
+        'Unknown Title';
+
+    final artistRuns =
+        _readNested(renderer, ['longBylineText', 'runs']) ??
+        _readNested(renderer, ['shortBylineText', 'runs']) ??
+        const <dynamic>[];
+    final artists = _extractArtists(artistRuns);
+    final artist = artists.isEmpty ? 'Unknown Artist' : artists.join(', ');
+
+    final thumbnail =
+        _pickLastThumbnail(
+          _readNested(renderer, ['thumbnail', 'thumbnails']),
+        ) ??
+        _pickLastThumbnail(
+          _readNested(renderer, [
+            'thumbnail',
+            'musicThumbnailRenderer',
+            'thumbnail',
+            'thumbnails',
+          ]),
+        ) ??
+        '';
+
+    final navigationEndpoint =
+        renderer['navigationEndpoint'] ??
+        renderer['playNavigationEndpoint'] ??
+        _readNested(renderer, [
+          'thumbnailOverlay',
+          'musicItemThumbnailOverlayRenderer',
+          'content',
+          'musicPlayButtonRenderer',
+          'playNavigationEndpoint',
+        ]);
+    final watchEndpoint = _readNested(navigationEndpoint, ['watchEndpoint']);
+
+    return YtMusicQueueTrack(
+      ytid: videoId,
+      title: title,
+      artist: artist,
+      image: thumbnail,
+      duration: _parseDurationInSeconds(
+        _readNested(renderer, ['lengthText', 'simpleText'])?.toString() ??
+            _joinRuns(_readNested(renderer, ['lengthText', 'runs'])),
+      ),
+      queuePlaylistId: _readNested(watchEndpoint, ['playlistId'])?.toString(),
+      queueParams: _readNested(watchEndpoint, ['params'])?.toString(),
+    );
+  }
+
+  List<String> _extractArtists(dynamic runs) {
+    if (runs is! List) {
+      return const [];
+    }
+
+    final artists = <String>[];
+    final seen = <String>{};
+
+    for (final run in runs) {
+      if (run is! Map) continue;
+      final text = run['text']?.toString().trim() ?? '';
+      if (text.isEmpty || text == '•') {
+        continue;
+      }
+
+      final browseId = _readNested(run, [
+        'navigationEndpoint',
+        'browseEndpoint',
+        'browseId',
+      ])?.toString();
+      if (browseId != null &&
+          browseId.isNotEmpty &&
+          !browseId.startsWith('UC')) {
+        continue;
+      }
+
+      if (seen.add(text.toLowerCase())) {
+        artists.add(text);
+      }
+    }
+
+    return artists;
+  }
+
+  String? _joinRuns(dynamic runs) {
+    if (runs is! List) {
+      return null;
+    }
+
+    final text = runs
+        .whereType<Map>()
+        .map((run) => run['text']?.toString() ?? '')
+        .join()
+        .trim();
+    return text.isEmpty ? null : text;
+  }
+
+  String? _pickLastThumbnail(dynamic thumbnails) {
+    if (thumbnails is! List || thumbnails.isEmpty) {
+      return null;
+    }
+
+    for (var i = thumbnails.length - 1; i >= 0; i--) {
+      final item = thumbnails[i];
+      if (item is Map && item['url'] != null) {
+        return item['url'].toString();
+      }
+    }
+
+    return null;
+  }
+
+  int? _parseDurationInSeconds(String? value) {
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+
+    final parts = value
+        .split(':')
+        .map((part) => int.tryParse(part.trim()))
+        .toList();
+    if (parts.any((part) => part == null)) {
+      return null;
+    }
+
+    if (parts.length == 2) {
+      return parts[0]! * 60 + parts[1]!;
+    }
+    if (parts.length == 3) {
+      return parts[0]! * 3600 + parts[1]! * 60 + parts[2]!;
+    }
+    return null;
+  }
+
+  String? _extractContinuationToken(Map<String, dynamic> response) {
+    final directItems = _extractDirectPanelItems(response);
+    for (final item in directItems) {
+      final token = _readNested(item, [
+        'continuationItemRenderer',
+        'continuationEndpoint',
+        'continuationCommand',
+        'token',
+      ])?.toString();
+      if (token != null && token.isNotEmpty) {
+        return token;
+      }
+    }
+
+    return _findContinuationToken(response);
+  }
+
+  String? _findContinuationToken(dynamic node, {int depth = 0}) {
+    if (node == null || depth > 12) {
+      return null;
+    }
+
+    if (node is List) {
+      for (final item in node) {
+        final token = _findContinuationToken(item, depth: depth + 1);
+        if (token != null && token.isNotEmpty) {
+          return token;
+        }
+      }
+      return null;
+    }
+
+    if (node is! Map) {
+      return null;
+    }
+
+    final directToken =
+        _readNested(node, [
+          'continuationItemRenderer',
+          'continuationEndpoint',
+          'continuationCommand',
+          'token',
+        ]) ??
+        _readNested(node, [
+          'continuations',
+          '0',
+          'nextContinuationData',
+          'continuation',
+        ]);
+    if (directToken is String && directToken.isNotEmpty) {
+      return directToken;
+    }
+
+    for (final value in node.values) {
+      final token = _findContinuationToken(value, depth: depth + 1);
+      if (token != null && token.isNotEmpty) {
+        return token;
+      }
+    }
+
+    return null;
+  }
+
+  dynamic _readNested(dynamic node, List<String> path) {
+    var current = node;
+    for (final key in path) {
+      if (current is List) {
+        final index = int.tryParse(key);
+        if (index == null || index < 0 || index >= current.length) {
+          return null;
+        }
+        current = current[index];
+        continue;
+      }
+      if (current is! Map) {
+        return null;
+      }
+      current = current[key];
+    }
+    return current;
+  }
+}

--- a/lib/utilities/sharing_intent.dart
+++ b/lib/utilities/sharing_intent.dart
@@ -41,7 +41,7 @@ Future<void> handleYoutubeSharedTextIntent(
 
   try {
     final song = await getSongDetails(0, songId);
-    await audioHandler.playSong(song);
+    await audioHandler.playSingleSong(song);
   } catch (e, stackTrace) {
     onError(e, stackTrace);
   }

--- a/lib/widgets/song_bar.dart
+++ b/lib/widgets/song_bar.dart
@@ -176,9 +176,9 @@ class _SongBarState extends State<SongBar> {
     }
 
     if (widget.clearPlaylist) {
-      audioHandler.addPlaylistToQueue([widget.song], replace: true);
+      audioHandler.playSingleSong(widget.song);
     } else {
-      audioHandler.playSong(widget.song);
+      audioHandler.playSingleSong(widget.song);
     }
   }
 
@@ -387,7 +387,10 @@ class _SongBarState extends State<SongBar> {
     // Capture localization strings before building menu items to avoid
     // accessing context.l10n inside ValueListenableBuilder which can fail
     // when the widget is being disposed
-    final l10n = context.l10n!;
+    final l10n = context.l10n;
+    if (l10n == null) {
+      return <PopupMenuEntry<String>>[];
+    }
     final playNextText = l10n.playNext;
     final addToQueueText = l10n.addToQueue;
     final removeFromLikedSongsText = l10n.removeFromLikedSongs;


### PR DESCRIPTION
## Summary
- add a YouTube Music watch-next queue hydrator for standalone playback
- integrate queue generation into the audio handler so non-playlist playback grows into a contextual queue
- improve rapid skip handling so the latest requested target wins without briefly playing intermediate tracks
- seed a fresh queue again near queue end for non-playlist playback
- remove the automatic song picker setting and related logic to avoid conflicts with the new queue flow
- update the debug workflow to use the current artifact action version

## Testing
- flutter analyze
- manual testing of standalone playback queue generation
- manual testing of rapid skip behavior
- manual testing of queue growth near queue end

## Testing notes
- Play next works as expected
- Add to queue works as expected
- The earlier rapid-skip issue where intermediate songs briefly played has been fixed in my testing