### PR TITLE
fix(share): add feedback toast and error handling to share button

### DIFF
--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -194,6 +194,7 @@
   "settingChangedMsg": "Settings updated successfully",
   "settings": "Settings",
   "share": "Share",
+  "linkCopied": "Playlist link copied to clipboard",
   "shuffle": "Shuffle",
   "skipToNext": "Skip to next",
   "skipToPrevious": "Skip to previous",

--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -352,11 +352,21 @@ class _PlaylistPageState extends State<PlaylistPage> {
       icon: const Icon(FluentIcons.share_24_regular),
       iconSize: 24,
       onPressed: () async {
-        final encodedPlaylist = PlaylistSharingService.encodePlaylist(
-          _playlist,
-        );
-        final url = 'musify://playlist/custom/$encodedPlaylist';
-        await Clipboard.setData(ClipboardData(text: url));
+        try {
+          final encodedPlaylist = PlaylistSharingService.encodePlaylist(
+            _playlist,
+          );
+          final url = 'musify://playlist/custom/$encodedPlaylist';
+          await Clipboard.setData(ClipboardData(text: url));
+          if (mounted) {
+            showToast(context, context.l10n!.linkCopied);
+          }
+        } catch (e, stackTrace) {
+          logger.log('Error sharing playlist', error: e, stackTrace: stackTrace);
+          if (mounted) {
+            showToast(context, context.l10n!.error);
+          }
+        }
       },
       tooltip: context.l10n!.share,
     );


### PR DESCRIPTION
#### **Problem**
The playlist share button previously lacked any visual feedback, making it appear as though the button was non-functional. Furthermore, any internal errors during the link generation or clipboard copy process were handled silently, leaving neither the user nor the developer with information about what went wrong.

#### **Solution**
This PR improves the user experience and reliability of the sharing feature by implementing two main changes:

1.  **Direct Feedback (Toast):** Added a toast notification that triggers immediately after a playlist link is successfully copied to the clipboard. This confirms to the user that the action was performed.
2.  **Error Handling & Logging:** Wrapped the sharing logic in a `try-catch` block. 
    *   If an error occurs, a generic error toast is shown to the user.
    *   The error and its stack trace are now sent to the Logger, facilitating future debugging based on user reports of "it's not working."

#### **Changes**
- Modified lib/screens/playlist_page.dart to include feedback and error handling in the share button logic.
- Added `linkCopied` localization key to lib/localization/app_en.arb