### PR TITLE
fix: keep full queue when searching in lists

### DIFF
--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -677,9 +677,10 @@ class _PlaylistPageState extends State<PlaylistPage> {
     final isUserCreatedPlaylist = _playlist?['source'] == 'user-created';
     final playlistId = isUserCreatedPlaylist ? _playlist!['ytid'] : null;
     final isSearching = _searchQueryNotifier.value.isNotEmpty;
-    final playlistForQueue = isSearching
-        ? {..._playlist as Map, 'list': sourceList}
-        : _playlist;
+    final fullList = _playlist?['list'] as List<dynamic>? ?? [];
+    final fullIndex = isSearching
+        ? fullList.indexWhere((s) => s is Map && s['ytid'] == song['ytid'])
+        : index;
 
     return SongBar(
       song,
@@ -698,8 +699,8 @@ class _PlaylistPageState extends State<PlaylistPage> {
           : null,
       onPlay: () {
         audioHandler.playPlaylistSong(
-          playlist: playlistForQueue,
-          songIndex: index,
+          playlist: _playlist,
+          songIndex: fullIndex != -1 ? fullIndex : index,
         );
       },
       borderRadius: borderRadius,

--- a/lib/screens/user_songs_page.dart
+++ b/lib/screens/user_songs_page.dart
@@ -338,7 +338,7 @@ class _UserSongsPageState extends State<UserSongsPage> {
               'ytid': '',
               'title': title,
               'source': 'user-created',
-              'list': displayList,
+              'list': songsList,
             };
 
             if (displayList.isEmpty) {
@@ -424,17 +424,14 @@ class _UserSongsPageState extends State<UserSongsPage> {
       song,
       true,
       onPlay: () {
-        final currentQueue = audioHandler.currentQueue;
-        final isSameQueue =
-            currentQueue.length == playlist['list'].length &&
-            index < currentQueue.length &&
-            currentQueue[index] == song;
-
-        if (isSameQueue) {
-          audioHandler.skipToSong(index);
-        } else {
-          audioHandler.playPlaylistSong(playlist: playlist, songIndex: index);
-        }
+        final fullList = playlist['list'] as List<dynamic>? ?? [];
+        final fullIndex = fullList.indexWhere(
+          (s) => s is Map && s['ytid'] == song['ytid'],
+        );
+        audioHandler.playPlaylistSong(
+          playlist: playlist,
+          songIndex: fullIndex != -1 ? fullIndex : index,
+        );
       },
       borderRadius: borderRadius,
       isRecentSong: isRecentSong,


### PR DESCRIPTION
## Summary
Fixes queue truncation when playing songs during search in playlists and user songs lists.

## Problem
When users searched within a playlist or user songs list (liked songs, offline songs, recents), and then played a song from the search results, the queue was limited to only the filtered search results instead of the full playlist. This caused playback to stop after the last search result instead of continuing through the entire playlist.

## Solution
Instead of passing the filtered/displayed list to `playPlaylistSong`, the code now:

1. **playlist_page.dart**: 
   - Gets the full playlist's song list (`_playlist['list']`)
   - Finds the song's original index in the full list using its `ytid`
   - Passes the full playlist and correct index to `playPlaylistSong`

2. **user_songs_page.dart**:
   - Passes the complete `songsList` instead of the filtered `displayList`
   - Finds the song's index in the full list using `ytid`
   - Ensures the entire playlist remains available for playback

## Files Changed
- `lib/screens/playlist_page.dart` (+6, -5 lines)
- `lib/screens/user_songs_page.dart` (+9, -12 lines)

## Testing
- Tested searching within a playlist, then playing a song
- Verified queue contains full playlist after search playback
- Tested in liked songs, offline songs, and recents lists
- Verified normal playback (without search) still works correctly

## Notes
- This PR works independently but complements the `fix/add-to-queue` branch
- Both PRs can be merged without conflicts
