### PR TITLE
Fix/add to queue and play next 

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -739,7 +739,9 @@ class MusifyAudioHandler extends BaseAudioHandler {
         insertIndex = _queueList.length;
       }
 
-      _queueList.insert(insertIndex, _queueEntryIds.createSong(song));
+      final queueSong = _queueEntryIds.createSong(song);
+      queueSong['isManuallyAdded'] = true;
+      _queueList.insert(insertIndex, queueSong);
 
       if (_currentQueueIndex < 0) {
         _currentQueueIndex = 0;
@@ -801,7 +803,9 @@ class MusifyAudioHandler extends BaseAudioHandler {
     int? startIndex,
   }) async {
     try {
+      List<Map> manuallyAddedSongs = [];
       if (replace) {
+        manuallyAddedSongs = _queueList.where((song) => song['isManuallyAdded'] == true).toList();
         _queueList.clear();
         _originalQueueList.clear();
         _currentQueueIndex = 0;
@@ -824,6 +828,13 @@ class MusifyAudioHandler extends BaseAudioHandler {
             targetQueueIndex = _queueList.length - 1;
           }
         }
+      }
+
+      if (replace && manuallyAddedSongs.isNotEmpty) {
+        final insertIndex = targetQueueIndex != null 
+            ? targetQueueIndex + 1 
+            : (_queueList.isNotEmpty ? 1 : 0);
+        _queueList.insertAll(insertIndex, manuallyAddedSongs);
       }
 
       _hydrateQueueEntryIds();

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -805,7 +805,10 @@ class MusifyAudioHandler extends BaseAudioHandler {
     try {
       List<Map> manuallyAddedSongs = [];
       if (replace) {
-        manuallyAddedSongs = _queueList.where((song) => song['isManuallyAdded'] == true).toList();
+        manuallyAddedSongs = _queueList
+            .skip(_currentQueueIndex >= 0 ? _currentQueueIndex + 1 : 0)
+            .where((song) => song['isManuallyAdded'] == true)
+            .toList();
         _queueList.clear();
         _originalQueueList.clear();
         _currentQueueIndex = 0;
@@ -1822,6 +1825,13 @@ class MusifyAudioHandler extends BaseAudioHandler {
         final currentSong = _queueList[_currentQueueIndex];
         final currentQueueEntryId = _queueEntryIds.ensureId(currentSong);
 
+        final unplayedManualSongs = _queueList
+            .skip(_currentQueueIndex >= 0 ? _currentQueueIndex + 1 : 0)
+            .where((song) => song['isManuallyAdded'] == true)
+            .toList();
+        final manualSongIds = unplayedManualSongs.map((s) => _queueEntryIds.ensureId(s)).toSet();
+        _queueList.removeWhere((song) => manualSongIds.contains(_queueEntryIds.ensureId(song)));
+
         _queueList.shuffle();
 
         final newCurrentIndex = _queueList.indexWhere(
@@ -1834,6 +1844,8 @@ class MusifyAudioHandler extends BaseAudioHandler {
             ..insert(0, currentSong);
         }
 
+        _queueList.insertAll(_queueList.isNotEmpty ? 1 : 0, unplayedManualSongs);
+
         _currentQueueIndex = 0;
         _updateQueueMediaItems();
       } else if (!shuffleEnabled && wasShuffled) {
@@ -1842,7 +1854,14 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
           final currentSong = _queueList[_currentQueueIndex];
           final currentQueueEntryId = _queueEntryIds.ensureId(currentSong);
+          final unplayedManualSongs = _queueList
+              .skip(_currentQueueIndex >= 0 ? _currentQueueIndex + 1 : 0)
+              .where((song) => song['isManuallyAdded'] == true)
+              .toList();
+          final manualSongIds = unplayedManualSongs.map((s) => _queueEntryIds.ensureId(s)).toSet();
+
           final restoredQueue = cloneMaps(_originalQueueList);
+          restoredQueue.removeWhere((song) => manualSongIds.contains(_queueEntryIds.ensureId(song)));
 
           _queueList
             ..clear()
@@ -1855,6 +1874,11 @@ class MusifyAudioHandler extends BaseAudioHandler {
           if (_currentQueueIndex == -1) {
             _currentQueueIndex = 0;
           }
+
+          final insertIndex = _currentQueueIndex >= 0 && _currentQueueIndex < _queueList.length 
+              ? _currentQueueIndex + 1 
+              : _queueList.length;
+          _queueList.insertAll(insertIndex, unplayedManualSongs);
 
           _originalQueueList.clear();
           _updateQueueMediaItems();


### PR DESCRIPTION
## Summary
Fixes the issue where songs added via "Play Next" or "Add to Queue" disappear when the queue is replaced or reordered.

## Problem
When users added songs to the queue using the "Play Next" or "Add to Queue" buttons, the songs would disappear if:
- A new playlist was played (replacing the queue)
- The shuffle mode was toggled

## Solution
Introduced an `isManuallyAdded` flag to track songs that were explicitly added by the user. This flag is set when songs are added via:
- `playNext()`
- `addToQueue()`

The implementation preserves manually added songs in three scenarios:

1. **Queue replacement** (`addPlaylistToQueue` with `replace=true`)
   - Before clearing the queue, extract all unplayed manually added songs
   - After populating the new queue, re-insert manually added songs after the currently playing song

2. **Shuffle activation**
   - Extract manually added songs before shuffling
   - Insert them back after the current song position (index 1) after shuffle completes

3. **Shuffle deactivation**
   - Extract manually added songs from the shuffled queue
   - Remove them from the restored original queue
   - Re-insert them after the current song position

## Behavior
- Manually added songs persist until they are played
- Songs are always inserted right after the currently playing song (index `_currentQueueIndex + 1`)
- This is slightly more permissive than Spotify's implementation (which only preserves songs when reordering), but provides better UX as users don't lose songs they intentionally queued


