### PR TITLE
fix: extend manifest timeout and prune dead proxies

### DIFF
--- a/lib/services/common_services.dart
+++ b/lib/services/common_services.dart
@@ -64,7 +64,7 @@ String? lastFetchedLyrics;
 final _clients = [customAndroidVr, customAndroidSdkless];
 
 // Timeouts and durations used across manifest fetching and cache validation.
-const Duration _manifestTimeout = Duration(seconds: 12);
+const Duration _manifestTimeout = Duration(seconds: 30);
 const Duration _cacheValidationDuration = Duration(hours: 1);
 
 /// Fetches a stream manifest for a song, honoring proxy settings.

--- a/lib/services/proxy_manager.dart
+++ b/lib/services/proxy_manager.dart
@@ -171,6 +171,7 @@ class ProxyManager {
             error: e,
             stackTrace: stackTrace,
           );
+          _discardProxy(proxy, reason: 'shared client init failed');
           continue;
         }
       } while (true);
@@ -224,6 +225,7 @@ class ProxyManager {
         error: e,
         stackTrace: stackTrace,
       );
+      _discardProxy(proxy, reason: 'validation failed');
       return null;
     } finally {
       try {
@@ -268,7 +270,8 @@ class ProxyManager {
             _proxiesByCountry.containsKey(preferredCountry)) {
           countryCode = preferredCountry;
         } else {
-          countryCode = _proxiesByCountry.keys.first;
+          final countries = _proxiesByCountry.keys.toList(growable: false);
+          countryCode = countries[_random.nextInt(countries.length)];
         }
         final countryProxies = _proxiesByCountry[countryCode];
         if (countryProxies == null || countryProxies.isEmpty) {
@@ -363,6 +366,43 @@ class ProxyManager {
     }
   }
 
+  void _discardProxy(ProxyInfo proxy, {String? reason}) {
+    final address = proxy.address;
+
+    _proxiesByCountry.removeWhere((_, proxies) {
+      proxies.removeWhere((candidate) => candidate.address == address);
+      return proxies.isEmpty;
+    });
+    _workingProxies.removeWhere((candidate) => candidate.address == address);
+
+    final resources = _proxyResources.remove(address);
+    if (resources != null) {
+      try {
+        resources.close();
+      } catch (e, stackTrace) {
+        logger.log(
+          'ProxyManager: Error closing discarded proxy resources',
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+
+    if (_sharedProxyAddress == address) {
+      if (_sharedYt != null && _sharedYt != _defaultYt) {
+        try {
+          _sharedYt?.close();
+        } catch (_) {}
+      }
+      _sharedYt = _defaultYt;
+      _sharedProxyAddress = null;
+    }
+
+    logger.log(
+      'ProxyManager: discarded proxy $address${reason != null ? ' ($reason)' : ''}',
+    );
+  }
+
   Future<StreamManifest?> getSongManifest(String songId) async {
     if (!useProxy.value) {
       return _validateDirect(songId, _validateDirectTimeout);
@@ -402,7 +442,9 @@ class ProxyManager {
     int timeoutSeconds = 10,
   }) async {
     if (!useProxy.value || _sharedProxyAddress == null) {
-      return http.get(uri, headers: headers).timeout(
+      return http
+          .get(uri, headers: headers)
+          .timeout(
             Duration(seconds: timeoutSeconds),
             onTimeout: () => http.Response('Timeout', 408),
           );
@@ -410,13 +452,17 @@ class ProxyManager {
 
     final res = _proxyResources[_sharedProxyAddress!];
     if (res == null) {
-      return http.get(uri, headers: headers).timeout(
+      return http
+          .get(uri, headers: headers)
+          .timeout(
             Duration(seconds: timeoutSeconds),
             onTimeout: () => http.Response('Timeout', 408),
           );
     }
 
-    return res.ioClient.get(uri, headers: headers).timeout(
+    return res.ioClient
+        .get(uri, headers: headers)
+        .timeout(
           Duration(seconds: timeoutSeconds),
           onTimeout: () => http.Response('Timeout', 408),
         );
@@ -475,6 +521,7 @@ class ProxyManager {
           error: e,
           stackTrace: stackTrace,
         );
+        _discardProxy(proxy, reason: 'youtube client creation failed');
         continue;
       }
     } while (true);

--- a/lib/services/proxy_manager.dart
+++ b/lib/services/proxy_manager.dart
@@ -97,6 +97,7 @@ class ProxyManager {
   bool _hasFetched = false;
   final Map<String, List<ProxyInfo>> _proxiesByCountry = {};
   final Set<ProxyInfo> _workingProxies = {};
+  final Set<String> _blockedProxyAddresses = {};
   final _random = Random();
   DateTime _lastFetched = DateTime.now();
   DateTime _lastProxyCleanup = DateTime.now();
@@ -131,6 +132,33 @@ class ProxyManager {
         stackTrace: stackTrace,
       );
     }
+  }
+
+  bool _isBlockedProxyAddress(String address) {
+    return _blockedProxyAddresses.contains(address);
+  }
+
+  void _addProxyCandidate({
+    required String source,
+    required String address,
+    required String country,
+    bool? isSsl,
+  }) {
+    if (_isBlockedProxyAddress(address)) return;
+
+    final countryProxies = _proxiesByCountry.putIfAbsent(country, () => []);
+    if (countryProxies.any((candidate) => candidate.address == address)) {
+      return;
+    }
+
+    countryProxies.add(
+      ProxyInfo(
+        source: source,
+        address: address,
+        country: country,
+        isSsl: isSsl,
+      ),
+    );
   }
 
   /// Initialize a shared YoutubeExplode client that uses a working proxy.
@@ -211,6 +239,7 @@ class ProxyManager {
   ) async {
     if (!useProxy.value) return null;
     YoutubeExplode? ytClient;
+    var shouldCloseClient = false;
     try {
       final res = _ensureProxyResources(proxy, timeoutSeconds: timeoutSeconds);
       ytClient = YoutubeExplode(httpClient: YoutubeHttpClient(res.ioClient));
@@ -218,6 +247,7 @@ class ProxyManager {
           .getManifest(songId, ytClients: [YoutubeApiClient.androidVr])
           .timeout(Duration(seconds: timeoutSeconds));
       _workingProxies.add(proxy);
+      shouldCloseClient = true;
       return manifest;
     } catch (e, stackTrace) {
       logger.log(
@@ -225,12 +255,14 @@ class ProxyManager {
         error: e,
         stackTrace: stackTrace,
       );
-      _discardProxy(proxy, reason: 'validation failed');
+      _discardProxy(proxy, reason: 'validation failed', closeResources: false);
       return null;
     } finally {
-      try {
-        ytClient?.close();
-      } catch (_) {}
+      if (shouldCloseClient) {
+        try {
+          ytClient?.close();
+        } catch (_) {}
+      }
     }
   }
 
@@ -246,6 +278,7 @@ class ProxyManager {
         _proxyCleanupIntervalMinutes) {
       _proxiesByCountry.clear();
       _workingProxies.clear();
+      _blockedProxyAddresses.clear();
       _hasFetched = false;
       _closeAllProxyResources();
     }
@@ -257,13 +290,19 @@ class ProxyManager {
       if (!_hasFetched) await (_fetchingProxiesFuture ?? _fetchProxies());
       if (_hasFetched && _proxiesByCountry.isEmpty) await _fetchProxies();
       if (_proxiesByCountry.isEmpty) return null;
+      _workingProxies.removeWhere(
+        (candidate) => _isBlockedProxyAddress(candidate.address),
+      );
       ProxyInfo proxy;
       String countryCode;
-      if (_workingProxies.isNotEmpty) {
-        final idx = _workingProxies.length == 1
+      final workingProxies = _workingProxies
+          .where((candidate) => !_isBlockedProxyAddress(candidate.address))
+          .toList(growable: false);
+      if (workingProxies.isNotEmpty) {
+        final idx = workingProxies.length == 1
             ? 0
-            : _random.nextInt(_workingProxies.length);
-        proxy = _workingProxies.elementAt(idx);
+            : _random.nextInt(workingProxies.length);
+        proxy = workingProxies[idx];
         _workingProxies.remove(proxy);
       } else {
         if (preferredCountry != null &&
@@ -273,10 +312,15 @@ class ProxyManager {
           final countries = _proxiesByCountry.keys.toList(growable: false);
           countryCode = countries[_random.nextInt(countries.length)];
         }
-        final countryProxies = _proxiesByCountry[countryCode];
+        final countryProxies = _proxiesByCountry[countryCode]
+            ?.where((candidate) => !_isBlockedProxyAddress(candidate.address))
+            .toList(growable: false);
         if (countryProxies == null || countryProxies.isEmpty) {
           if (_proxiesByCountry.isEmpty) return null;
-          final allProxies = _proxiesByCountry.values.expand((x) => x).toList();
+          final allProxies = _proxiesByCountry.values
+              .expand((x) => x)
+              .where((candidate) => !_isBlockedProxyAddress(candidate.address))
+              .toList(growable: false);
           if (allProxies.isEmpty) return null;
           proxy = allProxies[_random.nextInt(allProxies.length)];
         } else {
@@ -366,8 +410,13 @@ class ProxyManager {
     }
   }
 
-  void _discardProxy(ProxyInfo proxy, {String? reason}) {
+  void _discardProxy(
+    ProxyInfo proxy, {
+    String? reason,
+    bool closeResources = true,
+  }) {
     final address = proxy.address;
+    _blockedProxyAddresses.add(address);
 
     _proxiesByCountry.removeWhere((_, proxies) {
       proxies.removeWhere((candidate) => candidate.address == address);
@@ -377,13 +426,30 @@ class ProxyManager {
 
     final resources = _proxyResources.remove(address);
     if (resources != null) {
-      try {
-        resources.close();
-      } catch (e, stackTrace) {
-        logger.log(
-          'ProxyManager: Error closing discarded proxy resources',
-          error: e,
-          stackTrace: stackTrace,
+      if (closeResources) {
+        try {
+          resources.close();
+        } catch (e, stackTrace) {
+          logger.log(
+            'ProxyManager: Error closing discarded proxy resources',
+            error: e,
+            stackTrace: stackTrace,
+          );
+        }
+      } else {
+        // Let timed-out validation requests unwind before closing the client.
+        unawaited(
+          Future.delayed(const Duration(seconds: 2), () {
+            try {
+              resources.close();
+            } catch (e, stackTrace) {
+              logger.log(
+                'ProxyManager: Error closing discarded proxy resources',
+                error: e,
+                stackTrace: stackTrace,
+              );
+            }
+          }),
         );
       }
     }
@@ -556,15 +622,11 @@ class ProxyManager {
         if (match != null) {
           final country = match.namedGroup('country') ?? '';
           if (country.isNotEmpty) {
-            _proxiesByCountry[country] = _proxiesByCountry[country] ?? [];
-            _proxiesByCountry[country]!.add(
-              ProxyInfo(
-                source: 'spys.me',
-                address:
-                    '${match.namedGroup('ip')}:${match.namedGroup('port')}',
-                country: country,
-                isSsl: (match.namedGroup('ssl') ?? '').trim().isNotEmpty,
-              ),
+            _addProxyCandidate(
+              source: 'spys.me',
+              address: '${match.namedGroup('ip')}:${match.namedGroup('port')}',
+              country: country,
+              isSsl: (match.namedGroup('ssl') ?? '').trim().isNotEmpty,
             );
           }
         }
@@ -611,14 +673,11 @@ class ProxyManager {
             (proxyData['alive'] ?? false) &&
             proxyData['ip_data']['countryCode'] != null) {
           final country = proxyData['ip_data']['countryCode'];
-          _proxiesByCountry[country] = _proxiesByCountry[country] ?? [];
-          _proxiesByCountry[country]!.add(
-            ProxyInfo(
-              source: 'proxyscrape.com',
-              address: '${proxyData['ip']}:${proxyData['port']}',
-              country: country,
-              isSsl: true,
-            ),
+          _addProxyCandidate(
+            source: 'proxyscrape.com',
+            address: '${proxyData['ip']}:${proxyData['port']}',
+            country: country,
+            isSsl: true,
           );
         }
       }
@@ -645,15 +704,11 @@ class ProxyManager {
         if (match != null) {
           final country = match.namedGroup('country') ?? '';
           if (country.isNotEmpty) {
-            _proxiesByCountry[country] = _proxiesByCountry[country] ?? [];
-            _proxiesByCountry[country]!.add(
-              ProxyInfo(
-                source: 'openproxylist',
-                address:
-                    '${match.namedGroup('ip')}:${match.namedGroup('port')}',
-                country: country,
-                isSsl: true,
-              ),
+            _addProxyCandidate(
+              source: 'openproxylist',
+              address: '${match.namedGroup('ip')}:${match.namedGroup('port')}',
+              country: country,
+              isSsl: true,
             );
           }
         }
@@ -687,14 +742,11 @@ class ProxyManager {
         final country = item['country'];
 
         if (ip != null && port != null && country != null) {
-          _proxiesByCountry[country] = _proxiesByCountry[country] ?? [];
-          _proxiesByCountry[country]!.add(
-            ProxyInfo(
-              source: 'geonode',
-              address: '$ip:$port',
-              country: country,
-              isSsl: true,
-            ),
+          _addProxyCandidate(
+            source: 'geonode',
+            address: '$ip:$port',
+            country: country,
+            isSsl: true,
           );
         }
       }


### PR DESCRIPTION
This PR addresses #820 by extending the manifest timeout and hardening proxy handling.

- `_manifestTimeout` increased from 12s to 30s.
- Failing proxies are removed from the pool when validation or client initialization fails.
- Country selection in `ProxyManager` is randomized instead of always using the first key.

I validated the code locally, built a `github` debug APK, and confirmed the proxy cleanup path now logs discarded proxies instead of retrying the same dead address.
