### PR TITLE
fix: use gmstyle youtube_explode_dart fork

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -885,9 +885,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: e00fed3be4e4c8c07efdd1bc8c40329c966e7ba2
-      resolved-ref: e00fed3be4e4c8c07efdd1bc8c40329c966e7ba2
-      url: "https://github.com/Hexer10/youtube_explode_dart"
+      ref: "0e339cc0f38c5c6da139f88254aa9e7e64951672"
+      resolved-ref: "0e339cc0f38c5c6da139f88254aa9e7e64951672"
+      url: "https://github.com/gmstyle/youtube_explode_dart"
     source: git
     version: "3.0.5"
 sdks:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,8 +38,8 @@ dependencies:
   url_launcher: ^6.3.2
   youtube_explode_dart:
     git:
-      url: https://github.com/Hexer10/youtube_explode_dart
-      ref: e00fed3be4e4c8c07efdd1bc8c40329c966e7ba2
+      url: https://github.com/gmstyle/youtube_explode_dart
+      ref: 0e339cc0f38c5c6da139f88254aa9e7e64951672
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Tested it and it worked, with one small issue that could be improved: the song is being added to the queue only after the current track has already ended, and it is not auto-skipping immediately. (#819)