### PR TITLE
fix: respect offline playlist sort order in player queue

### DIFF
--- a/lib/screens/user_songs_page.dart
+++ b/lib/screens/user_songs_page.dart
@@ -206,11 +206,18 @@ class _UserSongsPageState extends State<UserSongsPage> {
                     label: Text(context.l10n!.play),
                     onPressed: () {
                       final songsList = getSongsList(widget.page);
+                      var sortedList = songsList;
+                      if (isOfflineSongs) {
+                        sortedList = _sortOfflineSongsLocal(
+                          songsList,
+                          _getCurrentOfflineSortType(),
+                        );
+                      }
                       final playlist = {
                         'ytid': '',
                         'title': title,
                         'source': 'user-created',
-                        'list': songsList,
+                        'list': sortedList,
                       };
                       audioHandler.playPlaylistSong(
                         playlist: playlist,
@@ -334,11 +341,18 @@ class _UserSongsPageState extends State<UserSongsPage> {
           builder: (_, searchQuery, __) {
             final isSearching = searchQuery.isNotEmpty;
             final displayList = _getDisplayList(songsList);
+            var sortedList = songsList;
+            if (isOfflineSongs) {
+              sortedList = _sortOfflineSongsLocal(
+                songsList,
+                _getCurrentOfflineSortType(),
+              );
+            }
             final playlist = {
               'ytid': '',
               'title': title,
               'source': 'user-created',
-              'list': songsList,
+              'list': sortedList,
             };
 
             if (displayList.isEmpty) {


### PR DESCRIPTION
## Description
This PR fixes a bug where the playback queue for "Offline Songs" would always follow the default order, ignoring any active sorting criteria (e.g., "Date Added", "Title", or "Artist").

## Changes
- Modified `UserSongsPage` to ensure that when a song is played (either via the main "Play" button or by tapping a specific song), the list passed to the `audioHandler` is correctly sorted according to the user's current selection.
- Used the existing `_sortOfflineSongsLocal` and `_getCurrentOfflineSortType` logic to derive the sorted list before initializing the playlist payload.
- This ensures the player queue matches the visual order of songs shown on the screen.

