### PR TITLE
fix: adjust create playlist card size in empty state

### DIFF
--- a/lib/utilities/playlist_dialogs.dart
+++ b/lib/utilities/playlist_dialogs.dart
@@ -395,17 +395,21 @@ void showAddToPlaylistDialog(
                   (folders.isNotEmpty) || (topLevelPlaylists.isNotEmpty);
 
               if (!hasAny) {
-                return Center(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 32),
-                    child: Text(
-                      context.l10n!.noCustomPlaylists,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 32),
+                      child: Text(
+                        context.l10n!.noCustomPlaylists,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                        textAlign: TextAlign.center,
                       ),
-                      textAlign: TextAlign.center,
                     ),
-                  ),
+                  ],
                 );
               }
 


### PR DESCRIPTION
### Description
Fixes an issue where the "Add to playlist" / "Create playlist" dialog would expand to take up 60% of the screen's height when the user has no custom playlists created (empty state).

### Changes
- Replaced the `Center` widget in the empty state of `showAddToPlaylistDialog` with a `Column(mainAxisSize: MainAxisSize.min)`. 
- The `Center` widget was aggressively expanding to the parent's maximum constraints (`MediaQuery.sizeOf(context).height * 0.6`), causing the dialog to look unnaturally huge. Using a constrained `Column` ensures the dialog fits tightly around the empty state message.
