### PR TITLE
fix: auto-register album as offline when all songs are downloaded

### DIFF
--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -525,6 +525,14 @@ class _PlaylistPageState extends State<PlaylistPage> {
             playlistOfflineStatus = isPlaylistFullyOffline(playlistSongs);
 
             if (playlistOfflineStatus) {
+              // Auto-register as offline playlist if not already registered.
+              // This handles the case where all songs were downloaded via
+              // another playlist, so the album/playlist shows the download
+              // icon but doesn't appear in the offline playlists section.
+              if (!offlinePlaylistService.isPlaylistDownloaded(playlistId)) {
+                offlinePlaylistService.registerAsOffline(_playlist);
+              }
+
               return IconButton.filled(
                 icon: Icon(
                   FluentIcons.arrow_download_off_24_filled,

--- a/lib/services/playlist_download_service.dart
+++ b/lib/services/playlist_download_service.dart
@@ -411,6 +411,36 @@ class OfflinePlaylistService {
     }
   }
 
+  /// Registers a playlist as offline without downloading anything.
+  /// Used when all songs are already downloaded (e.g. via another playlist).
+  void registerAsOffline(Map playlist) {
+    final playlistId = playlist['ytid']?.toString();
+    if (playlistId == null || playlistId.isEmpty) return;
+
+    // Already registered — nothing to do
+    if (isPlaylistDownloaded(playlistId)) return;
+
+    final offlinePlaylist = {
+      'ytid': playlistId,
+      'title': playlist['title'],
+      'image': playlist['image'],
+      'source': playlist['source'],
+      'list': playlist['list'] ?? [],
+      'downloadedAt': DateTime.now().millisecondsSinceEpoch,
+    };
+
+    final updatedPlaylists = List<dynamic>.from(offlinePlaylists.value)
+      ..add(offlinePlaylist);
+    offlinePlaylists.value = updatedPlaylists;
+    unawaited(
+      addOrUpdateData(
+        'userNoBackup',
+        'offlinePlaylists',
+        offlinePlaylists.value,
+      ),
+    );
+  }
+
   Map<String, dynamic> getDownloadStatus(String playlistId) {
     final isDownloaded = isPlaylistDownloaded(playlistId);
     final isDownloading = isPlaylistDownloading(playlistId);


### PR DESCRIPTION
#### Summary
This PR fixes a bug where albums or playlists would not appear in the "Offline" section even if all their songs were already downloaded (e.g., via another playlist or individually).

#### Changes
- **`OfflinePlaylistService`**: Added a new method `registerAsOffline` to persist playlist metadata locally without triggering new downloads.
- **`PlaylistPage`**: Implemented a check that automatically registers a playlist as offline if `isPlaylistFullyOffline` returns true but the playlist is not yet in the offline registry.

#### Why this is needed
Previously, if you had all songs of an album downloaded through different sources, the UI would show the "Downloaded" icon, but the album itself wouldn't show up in the Offline Playlists tab. This change ensures the local database stays in sync with the actual file availability.

