### PR TITLE
Fix/fast cancel playlist download

### DIFF
--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -66,6 +66,7 @@
   "download": "Download",
   "downloadAppUpdate": "Download app update",
   "downloadCancelled": "Download cancelled",
+  "cancellingDownload": "Cancelling download...",
   "downloadFailed": "Download failed",
   "downloadPlaylist": "Download playlist",
   "downloadsDeleted": "Downloads deleted successfully",

--- a/lib/localization/app_pt.arb
+++ b/lib/localization/app_pt.arb
@@ -66,6 +66,7 @@
   "download": "Baixar",
   "downloadAppUpdate": "Baixar atualização do app",
   "downloadCancelled": "Download cancelado",
+  "cancellingDownload": "Cancelando download...",
   "downloadFailed": "Falha no download",
   "downloadPlaylist": "Baixar playlist",
   "downloadsDeleted": "Downloads excluídos com sucesso",

--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -555,22 +555,23 @@ class _PlaylistPageState extends State<PlaylistPage> {
                           width: 40,
                           height: 40,
                           child: CircularProgressIndicator(
-                            value: progress.progress,
+                            value: progress.isCancelled ? null : progress.progress,
                             strokeWidth: 3,
                             backgroundColor: Theme.of(
                               context,
                             ).colorScheme.primaryContainer,
                           ),
                         ),
-                        IconButton(
-                          icon: const Icon(
-                            FluentIcons.dismiss_24_filled,
-                            size: 16,
+                        if (!progress.isCancelled)
+                          IconButton(
+                            icon: const Icon(
+                              FluentIcons.dismiss_24_filled,
+                              size: 16,
+                            ),
+                            onPressed: () => offlinePlaylistService
+                                .cancelDownload(context, playlistId),
+                            tooltip: context.l10n!.cancel,
                           ),
-                          onPressed: () => offlinePlaylistService
-                              .cancelDownload(context, playlistId),
-                          tooltip: context.l10n!.cancel,
-                        ),
                       ],
                     ),
                   );

--- a/lib/services/playlist_download_service.dart
+++ b/lib/services/playlist_download_service.dart
@@ -217,17 +217,32 @@ class OfflinePlaylistService {
     try {
       final progressNotifier = getProgressNotifier(playlistId);
       progressNotifier.value.isCancelled = true;
-      
-      // Immediately remove from active downloads to update status
-      activeDownloads.remove(playlistId);
-      
-      // Notify listeners so the UI rebuilds instantly with the new status
       progressNotifier.notifyListeners();
+
+      // Immediate visual feedback
+      showToast(context, '${context.l10n!.cancel}...');
+
+      const maxWaitTime = Duration(seconds: 30);
+      final startTime = DateTime.now();
+
+      // Wait for the ongoing tasks to complete with timeout
+      while (activeDownloads.contains(playlistId)) {
+        await Future.delayed(const Duration(milliseconds: 100));
+
+        if (DateTime.now().difference(startTime) > maxWaitTime) {
+          logger.log('Timeout waiting for download cancellation');
+          activeDownloads.remove(playlistId);
+          cleanupProgressNotifier(playlistId);
+          break;
+        }
+      }
 
       showToast(context, context.l10n!.downloadCancelled);
     } catch (e, stackTrace) {
       logger.log('Error cancelling download', error: e, stackTrace: stackTrace);
+      // Force remove from active downloads and cleanup on error
       activeDownloads.remove(playlistId);
+      cleanupProgressNotifier(playlistId);
     }
   }
 

--- a/lib/services/playlist_download_service.dart
+++ b/lib/services/playlist_download_service.dart
@@ -217,29 +217,17 @@ class OfflinePlaylistService {
     try {
       final progressNotifier = getProgressNotifier(playlistId);
       progressNotifier.value.isCancelled = true;
+      
+      // Immediately remove from active downloads to update status
+      activeDownloads.remove(playlistId);
+      
+      // Notify listeners so the UI rebuilds instantly with the new status
       progressNotifier.notifyListeners();
-
-      const maxWaitTime = Duration(seconds: 30);
-      final startTime = DateTime.now();
-
-      // Wait for the ongoing tasks to complete with timeout
-      while (activeDownloads.contains(playlistId)) {
-        await Future.delayed(const Duration(milliseconds: 100));
-
-        if (DateTime.now().difference(startTime) > maxWaitTime) {
-          logger.log('Timeout waiting for download cancellation');
-          activeDownloads.remove(playlistId);
-          cleanupProgressNotifier(playlistId);
-          break;
-        }
-      }
 
       showToast(context, context.l10n!.downloadCancelled);
     } catch (e, stackTrace) {
       logger.log('Error cancelling download', error: e, stackTrace: stackTrace);
-      // Force remove from active downloads and cleanup on error
       activeDownloads.remove(playlistId);
-      cleanupProgressNotifier(playlistId);
     }
   }
 

--- a/lib/services/playlist_download_service.dart
+++ b/lib/services/playlist_download_service.dart
@@ -220,7 +220,7 @@ class OfflinePlaylistService {
       progressNotifier.notifyListeners();
 
       // Immediate visual feedback
-      showToast(context, '${context.l10n!.cancel}...');
+      showToast(context, context.l10n!.cancellingDownload);
 
       const maxWaitTime = Duration(seconds: 30);
       final startTime = DateTime.now();
@@ -402,8 +402,8 @@ class OfflinePlaylistService {
   void cleanupProgressNotifier(String playlistId) {
     try {
       if (downloadProgressNotifiers.containsKey(playlistId)) {
-        final notifier = downloadProgressNotifiers.remove(playlistId);
-        notifier?.dispose();
+        final notifier = downloadProgressNotifiers[playlistId];
+        notifier?.value = DownloadProgress(total: 0);
       }
     } catch (e, stackTrace) {
       logger.log(


### PR DESCRIPTION
### Description
Fixes two issues with the playlist download cancel ("X") button:

1. **No feedback on click**: Clicking the "X" button would show no response 
   for up to 30 seconds, because the UI waited for the background worker to
   fully stop before updating anything.

2. **Re-download broken after cancel**: After cancelling, clicking the download
   button again would show the "Already downloading" toast without actually
   starting a new download. The user had to leave and re-enter the playlist
   page to recover.

### Changes
- **`playlist_download_service.dart`**: On cancel, immediately show a 
  "Cancelling download..." toast and mark `isCancelled = true` so the UI
  reacts at once. The background worker wait loop is preserved to ensure no
  race condition with a new download.
- **`playlist_download_service.dart`** (`cleanupProgressNotifier`): Instead of
  disposing and removing the `ValueNotifier`, it now resets its value to a
  clean state. This keeps the `ValueListenableBuilder` in the playlist page
  alive and correctly wired, fixing the re-download bug.
- **`playlist_page.dart`**: When `isCancelled` is true, the "X" button is
  hidden immediately and the progress ring switches to an indeterminate spinner,
  giving the user instant visual confirmation that the cancellation is in
  progress.
- **`app_en.arb`**: Added `cancellingDownload` string ("Cancelling download...").

cleanupProgressNotifier currently only resets the existing ValueNotifier and leaves it in downloadProgressNotifiers, so repeated cancel/start cycles with different playlistIds can accumulate unused notifiers in the singleton. The per-entry memory cost looks small, but the retention is real. I wouldn't block this PR on it, but it seems worth a follow-up to separate cancel feedback from notifier eviction/disposal so we don't grow the cache without breaking cancel behavior.