### PR TITLE
fix: track offline song plays in Recently Played and Most Played

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -1498,6 +1498,8 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
       await audioPlayer.play();
 
+      unawaited(updateRecentlyPlayed(song['ytid'], songFallback: song));
+
       if (!isOffline) {
         final cacheKey =
             'song_${song['ytid']}_${audioQualitySetting.value}_url';

--- a/lib/services/common_services.dart
+++ b/lib/services/common_services.dart
@@ -437,7 +437,6 @@ Future<String?> fetchSongStreamUrl(String songId, bool isLive) async {
     if (isLive) {
       final streamInfo = await ytClient.videos.streamsClient
           .getHttpLiveStreamUrl(VideoId(songId));
-      unawaited(updateRecentlyPlayed(songId));
       return streamInfo;
     }
 
@@ -447,7 +446,6 @@ Future<String?> fetchSongStreamUrl(String songId, bool isLive) async {
     // Try to get from cache
     final cachedUrl = await _getCachedSongUrl(cacheKey, _cacheDuration);
     if (cachedUrl != null) {
-      unawaited(updateRecentlyPlayed(songId));
       return cachedUrl;
     }
 
@@ -466,7 +464,6 @@ Future<String?> fetchSongStreamUrl(String songId, bool isLive) async {
 
     unawaited(addOrUpdateData('cache', cacheKey, url));
 
-    unawaited(updateRecentlyPlayed(songId));
     return url;
   } on TimeoutException catch (_) {
     logger.log('fetchSongStreamUrl request timed out for $songId');
@@ -705,7 +702,16 @@ Future<File?> _downloadAndSaveArtworkFile(String url, String filePath) async {
 
 const recentlyPlayedSongsLimit = 250;
 
-Future<void> updateRecentlyPlayed(dynamic songId) async {
+/// Updates the recently played list and listening count for [songId].
+///
+/// When [songFallback] is provided, its metadata is used to seed the history
+/// entry if the song has never been played before. This avoids a network
+/// request when registering offline songs whose metadata is already available
+/// locally (e.g. from [userOfflineSongs]).
+Future<void> updateRecentlyPlayed(
+  dynamic songId, {
+  Map? songFallback,
+}) async {
   try {
     if (userRecentlyPlayed.isNotEmpty &&
         userRecentlyPlayed[0]['ytid'] == songId) {
@@ -734,7 +740,9 @@ Future<void> updateRecentlyPlayed(dynamic songId) async {
       song['lastPlayed'] = DateTime.now();
       userRecentlyPlayed.insert(0, song);
     } else {
-      final newSongDetails = await getSongDetails(0, songId);
+      final newSongDetails = songFallback != null
+          ? Map<String, dynamic>.from(songFallback)
+          : await getSongDetails(0, songId);
       newSongDetails['listeningCount'] = 1;
       newSongDetails['lastPlayed'] = DateTime.now();
       userRecentlyPlayed.insert(0, newSongDetails);


### PR DESCRIPTION
## Problem

Songs played from **local offline storage** were never registered in the Recently Played history and therefore never appeared in — or contributed to — the **Most Played** section on the Home screen. The feature worked correctly only for streamed songs.

## Root Cause

Two coupled issues:

1. `updateRecentlyPlayed` was called exclusively inside `fetchSongStreamUrl`, which is only invoked for online/streaming playback. The offline path (`_getOfflineSongUrl`) had no equivalent call.
2. `updateRecentlyPlayed` called `getSongDetails` (a YouTube API network request) for songs not yet in the history. This fails silently when the device is offline, swallowing the registration entirely.

## Fix

- Removed `updateRecentlyPlayed` calls from `fetchSongStreamUrl` (URL resolution should not carry history side-effects).
- Added a single `updateRecentlyPlayed` call in `_setAudioSourceAndPlay`, immediately after `audioPlayer.play()` succeeds — the shared success path for **both** online and offline playback.
- Added an optional `Map? songFallback` parameter to `updateRecentlyPlayed`. When a song is new to the history and local metadata is already available, it is used directly instead of making a network request, making offline registration fully reliable without internet access.

## Potential Enhancements

- **Play-duration threshold**: Only count a play after a minimum duration (e.g. 30 s) or after the song completes successfully, to avoid counting skipped or interrupted plays toward the listen count.
- **Retrospective / Wrapped page**: The `listeningCount` and `lastPlayed` fields are already persisted per song in Hive. A dedicated "Retrospective" or "Wrapped"-style page could surface yearly/monthly listening stats, top artists, total minutes listened, etc., leveraging this data with no additional tracking infrastructure required.
