### PR TITLE
UI: Make miniplayer float with transparent background

### DIFF
--- a/lib/screens/bottom_navigation_page.dart
+++ b/lib/screens/bottom_navigation_page.dart
@@ -96,10 +96,17 @@ class _BottomNavigationPageState extends State<BottomNavigationPage> {
                               _onTabTapped(index, items),
                         ),
                       Expanded(
-                        child: Column(
+                        child: Stack(
+                          alignment: Alignment.bottomCenter,
                           children: [
-                            Expanded(child: widget.child),
-                            const MiniPlayer(),
+                            widget.child,
+                            const Padding(
+                              padding: EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 8,
+                              ),
+                              child: MiniPlayer(),
+                            ),
                           ],
                         ),
                       ),

--- a/lib/widgets/mini_player.dart
+++ b/lib/widgets/mini_player.dart
@@ -180,6 +180,7 @@ class _MiniPlayerBodyState extends State<_MiniPlayerBody>
               height: MiniPlayer.playerHeight,
               decoration: BoxDecoration(
                 color: colorScheme.surfaceContainerHigh,
+                borderRadius: BorderRadius.circular(MiniPlayer._borderRadius),
                 boxShadow: [
                   BoxShadow(
                     color: colorScheme.shadow.withValues(alpha: 0.08),


### PR DESCRIPTION
### Description
This PR implements the floating miniplayer design by making the background transparent and letting list content scroll behind it.

### Changes
1. **`bottom_navigation_page.dart`**:
   - Replaced `Column` with a `Stack` containing the main page child and the `MiniPlayer` wrapped in a `Padding` widget.
   - This allows the scrollable list content to extend to the bottom of the screen and scroll behind the miniplayer.

2. **`mini_player.dart`**:
   - Added `borderRadius` to the container's `BoxDecoration`. 
   - Previously, only the internal child layout was clipped, leaving a solid rectangular background (with the theme's surface color) that was visible during scrolling. Applying the border radius directly to the container decoration ensures the space outside the rounded corners is completely transparent.
