### PR TITLE
perf: reduce startup blocking work

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -249,6 +249,9 @@ void main() async {
   await initialisation();
 
   runApp(const Musify());
+  SchedulerBinding.instance.addPostFrameCallback((_) {
+    unawaited(postRunInitialisation());
+  });
 }
 
 Future<void> initialisation() async {
@@ -287,16 +290,37 @@ Future<void> initialisation() async {
     } on PlatformException {
       logger.log('Failed to get initial uri');
     }
-
-    if (isFdroidBuild && !offlineMode.value) {
-      await fetchAnnouncementOnly();
-    }
   } catch (e, stackTrace) {
     logger.log('Initialization Error', error: e, stackTrace: stackTrace);
   }
 
   applicationDirPath = (await getApplicationDocumentsDirectory()).path;
-  await FilePaths.ensureDirectoriesExist();
+  unawaited(
+    FilePaths.ensureDirectoriesExist().catchError((
+      Object error,
+      StackTrace stackTrace,
+    ) {
+      logger.log(
+        'Failed to create application directories',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }),
+  );
+}
+
+Future<void> postRunInitialisation() async {
+  try {
+    if (isFdroidBuild && !offlineMode.value) {
+      await fetchAnnouncementOnly();
+    }
+  } catch (e, stackTrace) {
+    logger.log(
+      'Post-run initialization error',
+      error: e,
+      stackTrace: stackTrace,
+    );
+  }
 }
 
 void handleIncomingLink(Uri? uri) async {

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -43,6 +43,52 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  late Future<List<dynamic>> _suggestedPlaylistsFuture;
+  late Future<List<dynamic>> _likedPlaylistsFuture;
+  late Future<List<dynamic>> _recommendedSongsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _suggestedPlaylistsFuture = _loadSuggestedPlaylists();
+    _likedPlaylistsFuture = _loadSuggestedPlaylists(showOnlyLiked: true);
+    _recommendedSongsFuture = _loadRecommendedSongs();
+    currentLikedPlaylistsLength.addListener(_refreshLikedPlaylists);
+    externalRecommendations.addListener(_refreshRecommendedSongs);
+  }
+
+  @override
+  void dispose() {
+    currentLikedPlaylistsLength.removeListener(_refreshLikedPlaylists);
+    externalRecommendations.removeListener(_refreshRecommendedSongs);
+    super.dispose();
+  }
+
+  Future<List<dynamic>> _loadSuggestedPlaylists({
+    bool showOnlyLiked = false,
+  }) async {
+    return getPlaylists(
+      playlistsNum: recommendedCubesNumber,
+      onlyLiked: showOnlyLiked,
+    );
+  }
+
+  Future<List<dynamic>> _loadRecommendedSongs() async {
+    return getRecommendedSongs();
+  }
+
+  void _refreshLikedPlaylists() {
+    setState(() {
+      _likedPlaylistsFuture = _loadSuggestedPlaylists(showOnlyLiked: true);
+    });
+  }
+
+  void _refreshRecommendedSongs() {
+    setState(() {
+      _recommendedSongsFuture = _loadRecommendedSongs();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final playlistHeight = MediaQuery.sizeOf(context).height * 0.25 / 1.1;
@@ -94,10 +140,7 @@ class _HomePageState extends State<HomePage> {
         ? context.l10n!.backToFavorites
         : context.l10n!.suggestedPlaylists;
     return AsyncLoader<List<dynamic>>(
-      future: getPlaylists(
-        playlistsNum: recommendedCubesNumber,
-        onlyLiked: showOnlyLiked,
-      ),
+      future: showOnlyLiked ? _likedPlaylistsFuture : _suggestedPlaylistsFuture,
 
       builder: (context, playlists) {
         final itemsNumber = playlists.length.clamp(0, recommendedCubesNumber);
@@ -165,7 +208,7 @@ class _HomePageState extends State<HomePage> {
       valueListenable: externalRecommendations,
       builder: (_, recommendations, __) {
         return AsyncLoader<List<dynamic>>(
-          future: getRecommendedSongs(),
+          future: _recommendedSongsFuture,
 
           builder: (context, data) {
             if (data.isEmpty) return const SizedBox.shrink();

--- a/lib/services/io_service.dart
+++ b/lib/services/io_service.dart
@@ -43,15 +43,9 @@ class FilePaths {
 
   // Ensure directories exist
   static Future<void> ensureDirectoriesExist() async {
-    final tracksDirectory = Directory('$applicationDirPath/$tracksDir');
-    final artworksDirectory = Directory('$applicationDirPath/$artworksDir');
-
-    if (!await tracksDirectory.exists()) {
-      await tracksDirectory.create(recursive: true);
-    }
-
-    if (!await artworksDirectory.exists()) {
-      await artworksDirectory.create(recursive: true);
-    }
+    await Future.wait([
+      Directory('$applicationDirPath/$tracksDir').create(recursive: true),
+      Directory('$applicationDirPath/$artworksDir').create(recursive: true),
+    ]);
   }
 }


### PR DESCRIPTION
## Summary

- Defer the F-Droid announcement fetch until after the first frame.
- Cache Home page futures to avoid refetching suggested playlists/recommendations on unrelated rebuilds.
- Refresh the cached liked-playlists future when the liked playlist count changes.
- Create offline directories in parallel without blocking app startup, with error logging for background failures.

## Why

This keeps the PR focused on startup/performance only. Media-resumption related changes were removed from this PR and split into #851.

The incoming app-links listener is still registered during initialization, because `app_links` recommends subscribing early enough to catch the first link. Only non-critical post-startup work is deferred.

## Testing

- `flutter analyze`
- `flutter build apk --debug --flavor github -t lib/main.dart`