### PR TITLE
fix: show library actions when empty

### DIFF
--- a/lib/screens/library_page.dart
+++ b/lib/screens/library_page.dart
@@ -195,11 +195,11 @@ class _LibraryPageState extends State<LibraryPage> {
 
     final hasFolders = folders.isNotEmpty;
     final hasCustomPlaylists = playlistsNotInFolders.isNotEmpty;
-    final hasAnythingAfterOffline = hasFolders || hasCustomPlaylists;
+    final hasLibraryContent = !isOffline || hasFolders || hasCustomPlaylists;
 
     final slivers = <Widget>[];
 
-    if (hasAnythingAfterOffline) {
+    if (hasLibraryContent) {
       slivers.add(
         SliverToBoxAdapter(
           child: Column(
@@ -254,10 +254,10 @@ class _LibraryPageState extends State<LibraryPage> {
                       NavigationManager.router.go('/library/userSongs/offline'),
                   cubeIcon: FluentIcons.cloud_off_24_regular,
                   borderRadius: !isOffline
-                      ? (hasAnythingAfterOffline
+                      ? (hasCustomPlaylists || hasFolders
                             ? BorderRadius.zero
                             : commonCustomBarRadiusLast)
-                      : (hasAnythingAfterOffline
+                      : (hasCustomPlaylists || hasFolders
                             ? commonCustomBarRadiusFirst
                             : commonCustomBarRadius),
                   showBuildActions: false,


### PR DESCRIPTION
## Summary

- Show the Library base section even when a fresh install has no custom playlists or folders yet.
- Keep the create playlist/folder actions accessible from the Library empty state.
- Preserve the stricter offline-mode behavior so offline Library still only appears when there is usable offline content.

## Why

On a fresh install, the Library can render as a completely empty page because the section containing the create playlist actions is only shown after the user already has playlist content. That makes the Library look broken and removes the most obvious path to create a playlist from that screen.

## Testing

- `flutter analyze`
- `flutter build apk --debug --flavor github -t lib/main.dart`