### PR TITLE
fix: round card borders in dynamic sections

### DIFF
--- a/lib/screens/search_page.dart
+++ b/lib/screens/search_page.dart
@@ -354,6 +354,7 @@ class _SearchPageState extends State<SearchPage> {
       for (var index = 0; index < playlistsCount; index++) {
         final playlist = _playlistsSearchResult[index];
         final isLast = index == playlistsCount - 1;
+        final borderRadius = getItemBorderRadius(index, playlistsCount);
 
         widgets.add(
           Padding(
@@ -364,6 +365,7 @@ class _SearchPageState extends State<SearchPage> {
               playlistId: playlist['ytid'],
               playlistArtwork: playlist['image'],
               cubeIcon: FluentIcons.apps_list_24_filled,
+              borderRadius: borderRadius,
             ),
           ),
         );

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -80,6 +80,8 @@ class SettingsPage extends StatelessWidget {
     Color activatedColor,
     Color inactivatedColor,
   ) {
+    final isOffline = offlineMode.value;
+
     return Column(
       children: [
         SectionHeader(
@@ -167,6 +169,9 @@ class SettingsPage extends StatelessWidget {
               context.l10n!.offlineMode,
               FluentIcons.cloud_off_24_regular,
               description: context.l10n!.offlineModeDescription,
+              borderRadius: isOffline && isFdroidBuild
+                  ? commonCustomBarRadiusLast
+                  : BorderRadius.zero,
               trailing: Switch(
                 value: value,
                 onChanged: (value) => _toggleOfflineMode(context, value),
@@ -182,6 +187,9 @@ class SettingsPage extends StatelessWidget {
                 context.l10n!.automaticUpdateChecks,
                 FluentIcons.arrow_sync_24_regular,
                 description: context.l10n!.automaticUpdateChecksDescription,
+                borderRadius: offlineMode.value
+                    ? commonCustomBarRadiusLast
+                    : BorderRadius.zero,
                 trailing: Switch(
                   value: value ?? false,
                   onChanged: (value) =>


### PR DESCRIPTION
## Summary

- Apply the existing item border radius calculation to playlist search results.
- Round the last Preferences card correctly when offline mode hides the online settings section.
- Cover the F-Droid settings layout where automatic update checks are not shown.

## Why

Some dynamic card groups could lose their first/last border radius when nearby sections were hidden or when playlist search results were rendered. This made grouped cards look visually broken.

## Testing

- `flutter analyze`
- `flutter build apk --debug --flavor github -t lib/main.dart`