### PR TITLE
fix: prevent duplicate liked items

### DIFF
--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -369,10 +369,9 @@ class _PlaylistPageState extends State<PlaylistPage> {
                     updatePlaylistLikeStatus(
                       _playlist['ytid'],
                       playlistLikeStatus.value,
+                      playlistData: _playlist,
                     ),
                   );
-                  currentLikedPlaylistsLength.value =
-                      currentLikedPlaylistsLength.value - 1;
                 },
                 tooltip: context.l10n!.removeFromLikedSongs,
               )
@@ -385,10 +384,9 @@ class _PlaylistPageState extends State<PlaylistPage> {
                     updatePlaylistLikeStatus(
                       _playlist['ytid'],
                       playlistLikeStatus.value,
+                      playlistData: _playlist,
                     ),
                   );
-                  currentLikedPlaylistsLength.value =
-                      currentLikedPlaylistsLength.value + 1;
                 },
                 tooltip: context.l10n!.addToLikedSongs,
               );

--- a/lib/services/common_services.dart
+++ b/lib/services/common_services.dart
@@ -57,6 +57,8 @@ final currentRecentlyPlayedLength = ValueNotifier<int>(
   userRecentlyPlayed.length,
 );
 final recentlyPlayedVersion = ValueNotifier<int>(0);
+var _songLikeUpdateToken = 0;
+final _latestSongLikeUpdateTokens = <String, int>{};
 
 final lyrics = ValueNotifier<String?>(null);
 String? lastFetchedLyrics;
@@ -213,20 +215,44 @@ List _deduplicateAndShuffle(List playlistSongs) {
   return uniqueSongs;
 }
 
-Future<void> updateSongLikeStatus(dynamic songId, bool add) async {
+Future<void> updateSongLikeStatus(
+  dynamic songId,
+  bool add, {
+  Map? songData,
+}) async {
   try {
-    if (add) {
-      if (!userLikedSongsList.any((song) => song['ytid'] == songId)) {
-        final songDetails = await getSongDetails(
-          userLikedSongsList.length,
-          songId,
-        );
-        userLikedSongsList.add(songDetails);
-      }
-    } else {
-      userLikedSongsList.removeWhere((song) => song['ytid'] == songId);
+    final normalizedSongId = songId?.toString().trim() ?? '';
+    if (normalizedSongId.isEmpty) return;
+
+    final updateToken = ++_songLikeUpdateToken;
+    _latestSongLikeUpdateTokens[normalizedSongId] = updateToken;
+
+    final songToAdd = add
+        ? await _resolveSongForLikedStatus(normalizedSongId, songData)
+        : null;
+
+    if (_latestSongLikeUpdateTokens[normalizedSongId] != updateToken) {
+      return;
     }
 
+    final updatedLikedSongs = _deduplicateLikedSongs(userLikedSongsList);
+
+    if (add) {
+      if (songToAdd != null &&
+          !updatedLikedSongs.any(
+            (song) => song['ytid']?.toString() == normalizedSongId,
+          )) {
+        updatedLikedSongs.add(songToAdd);
+      }
+    } else {
+      updatedLikedSongs.removeWhere(
+        (song) => song['ytid']?.toString() == normalizedSongId,
+      );
+    }
+
+    if (_likedSongIdsAreEqual(userLikedSongsList, updatedLikedSongs)) return;
+
+    userLikedSongsList = updatedLikedSongs;
     currentLikedSongsLength.value = userLikedSongsList.length;
     unawaited(addOrUpdateData('user', 'likedSongs', userLikedSongsList));
   } catch (e, stackTrace) {
@@ -236,6 +262,68 @@ Future<void> updateSongLikeStatus(dynamic songId, bool add) async {
       stackTrace: stackTrace,
     );
   }
+}
+
+Future<Map?> _resolveSongForLikedStatus(String songId, Map? songData) async {
+  if (songData?['ytid']?.toString() == songId) {
+    return Map<String, dynamic>.from(songData!);
+  }
+
+  final cachedSong = _findSongById(userLikedSongsList, songId);
+  if (cachedSong != null) return Map<String, dynamic>.from(cachedSong);
+
+  return getSongDetails(userLikedSongsList.length, songId);
+}
+
+Map? _findSongById(Iterable<dynamic> songs, String songId) {
+  for (final song in songs) {
+    if (song is Map && song['ytid']?.toString() == songId) return song;
+  }
+
+  return null;
+}
+
+List _deduplicateLikedSongs(Iterable<dynamic> likedSongs) {
+  final seenSongIds = <String>{};
+  final deduplicatedSongs = [];
+
+  for (final song in likedSongs) {
+    if (song is! Map) {
+      deduplicatedSongs.add(song);
+      continue;
+    }
+
+    final songId = song['ytid']?.toString();
+    if (songId == null || songId.isEmpty) {
+      deduplicatedSongs.add(song);
+      continue;
+    }
+
+    if (seenSongIds.add(songId)) {
+      deduplicatedSongs.add(song);
+    }
+  }
+
+  return deduplicatedSongs;
+}
+
+bool _likedSongIdsAreEqual(List previous, List updated) {
+  if (previous.length != updated.length) return false;
+
+  for (var i = 0; i < previous.length; i++) {
+    final previousSong = previous[i];
+    final updatedSong = updated[i];
+    if (previousSong is! Map || updatedSong is! Map) {
+      if (previousSong != updatedSong) return false;
+      continue;
+    }
+
+    if (previousSong['ytid']?.toString() != updatedSong['ytid']?.toString()) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 void moveLikedSong(int oldIndex, int newIndex) {
@@ -275,11 +363,17 @@ Future<void> renameSongInLikedSongs(
   }
 }
 
-bool isSongAlreadyLiked(songIdToCheck) =>
-    userLikedSongsList.any((song) => song['ytid'] == songIdToCheck);
+bool isSongAlreadyLiked(songIdToCheck) {
+  final songId = songIdToCheck?.toString();
+  return userLikedSongsList.any((song) => song['ytid']?.toString() == songId);
+}
 
-bool isPlaylistAlreadyLiked(playlistIdToCheck) =>
-    userLikedPlaylists.any((playlist) => playlist['ytid'] == playlistIdToCheck);
+bool isPlaylistAlreadyLiked(playlistIdToCheck) {
+  final playlistId = playlistIdToCheck?.toString();
+  return userLikedPlaylists.any(
+    (playlist) => playlist['ytid']?.toString() == playlistId,
+  );
+}
 
 bool isSongAlreadyOffline(songIdToCheck) =>
     userOfflineSongs.any((song) => song['ytid'] == songIdToCheck);

--- a/lib/services/playlists_manager.dart
+++ b/lib/services/playlists_manager.dart
@@ -101,6 +101,8 @@ const pinnedPlaylistsLimit = 5;
 final currentLikedPlaylistsLength = ValueNotifier<int>(
   userLikedPlaylists.length,
 );
+var _playlistLikeUpdateToken = 0;
+final _latestPlaylistLikeUpdateTokens = <String, int>{};
 
 Future<List<dynamic>> getUserPlaylists() async {
   final futures = userPlaylists.value.map((playlistID) async {
@@ -467,9 +469,16 @@ bool _removePlaylistFromFolders(String playlistId) {
 }
 
 bool _removePlaylistFromLikedPlaylists(String playlistId) {
-  final previousLength = userLikedPlaylists.length;
-  userLikedPlaylists.removeWhere((playlist) => playlist['ytid'] == playlistId);
-  return userLikedPlaylists.length != previousLength;
+  final updatedLikedPlaylists = _deduplicateLikedPlaylists(userLikedPlaylists)
+    ..removeWhere((playlist) => playlist['ytid']?.toString() == playlistId);
+
+  if (_likedPlaylistIdsAreEqual(userLikedPlaylists, updatedLikedPlaylists)) {
+    return false;
+  }
+
+  userLikedPlaylists = updatedLikedPlaylists;
+  currentLikedPlaylistsLength.value = userLikedPlaylists.length;
+  return true;
 }
 
 String createPlaylistFolder(String folderName, [BuildContext? context]) {
@@ -1084,32 +1093,51 @@ Future<void> renameSongInPlaylist(
   }
 }
 
-Future<void> updatePlaylistLikeStatus(String playlistId, bool add) async {
+Future<void> updatePlaylistLikeStatus(
+  String playlistId,
+  bool add, {
+  Map? playlistData,
+}) async {
   try {
-    if (add) {
-      if (!userLikedPlaylists.any(
-        (playlist) => playlist['ytid'] == playlistId,
-      )) {
-        final playlist = playlists.firstWhere(
-          (playlist) => playlist['ytid'] == playlistId,
-          orElse: () => <String, dynamic>{},
-        );
+    final normalizedPlaylistId = playlistId.trim();
+    if (normalizedPlaylistId.isEmpty) return;
 
-        if (playlist.isNotEmpty) {
-          userLikedPlaylists.add(playlist);
-        } else {
-          final playlistInfo = await getPlaylistInfoForWidget(playlistId);
-          if (playlistInfo != null) {
-            userLikedPlaylists.add(playlistInfo);
-          }
-        }
+    final updateToken = ++_playlistLikeUpdateToken;
+    _latestPlaylistLikeUpdateTokens[normalizedPlaylistId] = updateToken;
+
+    final playlistToAdd = add
+        ? await _resolvePlaylistForLikedStatus(
+            normalizedPlaylistId,
+            playlistData,
+          )
+        : null;
+
+    if (_latestPlaylistLikeUpdateTokens[normalizedPlaylistId] != updateToken) {
+      return;
+    }
+
+    final updatedLikedPlaylists = _deduplicateLikedPlaylists(
+      userLikedPlaylists,
+    );
+
+    if (add) {
+      if (playlistToAdd != null &&
+          !updatedLikedPlaylists.any(
+            (playlist) => playlist['ytid']?.toString() == normalizedPlaylistId,
+          )) {
+        updatedLikedPlaylists.add(playlistToAdd);
       }
     } else {
-      userLikedPlaylists.removeWhere(
-        (playlist) => playlist['ytid'] == playlistId,
+      updatedLikedPlaylists.removeWhere(
+        (playlist) => playlist['ytid']?.toString() == normalizedPlaylistId,
       );
     }
 
+    if (_likedPlaylistIdsAreEqual(userLikedPlaylists, updatedLikedPlaylists)) {
+      return;
+    }
+
+    userLikedPlaylists = updatedLikedPlaylists;
     currentLikedPlaylistsLength.value = userLikedPlaylists.length;
     unawaited(addOrUpdateData('user', 'likedPlaylists', userLikedPlaylists));
   } catch (e, stackTrace) {
@@ -1119,6 +1147,54 @@ Future<void> updatePlaylistLikeStatus(String playlistId, bool add) async {
       stackTrace: stackTrace,
     );
   }
+}
+
+List<Map> _deduplicateLikedPlaylists(Iterable<Map> likedPlaylists) {
+  final seenPlaylistIds = <String>{};
+  final deduplicatedPlaylists = <Map>[];
+
+  for (final playlist in likedPlaylists) {
+    final playlistId = playlist['ytid']?.toString();
+    if (playlistId == null || playlistId.isEmpty) {
+      deduplicatedPlaylists.add(playlist);
+      continue;
+    }
+
+    if (seenPlaylistIds.add(playlistId)) {
+      deduplicatedPlaylists.add(playlist);
+    }
+  }
+
+  return deduplicatedPlaylists;
+}
+
+bool _likedPlaylistIdsAreEqual(List<Map> previous, List<Map> updated) {
+  if (previous.length != updated.length) return false;
+
+  for (var i = 0; i < previous.length; i++) {
+    if (previous[i]['ytid']?.toString() != updated[i]['ytid']?.toString()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+Future<Map?> _resolvePlaylistForLikedStatus(
+  String playlistId,
+  Map? playlistData,
+) async {
+  if (playlistData?['ytid']?.toString() == playlistId) {
+    return Map<String, dynamic>.from(playlistData!);
+  }
+
+  final cachedPlaylist = _searchAppPlaylistsById(playlistId);
+  if (cachedPlaylist != null) {
+    return Map<String, dynamic>.from(cachedPlaylist);
+  }
+
+  final playlistInfo = await getPlaylistInfoForWidget(playlistId);
+  return playlistInfo == null ? null : Map<String, dynamic>.from(playlistInfo);
 }
 
 bool isPlaylistPinned(String playlistId) =>

--- a/lib/widgets/now_playing/bottom_actions_row.dart
+++ b/lib/widgets/now_playing/bottom_actions_row.dart
@@ -155,7 +155,11 @@ class _BottomActionsRowState extends State<BottomActionsRow> {
               statusNotifier: _songLikeStatus,
               activeColor: colorScheme.primary,
               onPressed: () {
-                updateSongLikeStatus(widget.audioId, !_songLikeStatus.value);
+                updateSongLikeStatus(
+                  widget.audioId,
+                  !_songLikeStatus.value,
+                  songData: mediaItemToMap(widget.metadata),
+                );
                 _songLikeStatus.value = !_songLikeStatus.value;
               },
               tooltip: l10n.likedSongs,

--- a/lib/widgets/playlist_bar.dart
+++ b/lib/widgets/playlist_bar.dart
@@ -206,8 +206,13 @@ class PlaylistBar extends StatelessWidget {
           case 'like':
             if (_resolvedPlaylistId != null) {
               final isLiked = isPlaylistAlreadyLiked(_resolvedPlaylistId);
-              updatePlaylistLikeStatus(_resolvedPlaylistId!, !isLiked);
-              currentLikedPlaylistsLength.value += !isLiked ? 1 : -1;
+              unawaited(
+                updatePlaylistLikeStatus(
+                  _resolvedPlaylistId!,
+                  !isLiked,
+                  playlistData: playlistData,
+                ),
+              );
             }
             break;
           case 'pin':

--- a/lib/widgets/song_bar.dart
+++ b/lib/widgets/song_bar.dart
@@ -255,16 +255,12 @@ class _SongBarState extends State<SongBar> {
       case 'like':
         final newValue = !_songLikeStatus.value;
         _songLikeStatus.value = newValue;
-        final likedSongsLength = currentLikedSongsLength.value;
-        currentLikedSongsLength.value = newValue
-            ? likedSongsLength + 1
-            : likedSongsLength - 1;
-        updateSongLikeStatus(_ytid, newValue).catchError((e) {
-          logger.log('Error updating song like status', error: e);
-          // Revert on error
-          _songLikeStatus.value = !newValue;
-          currentLikedSongsLength.value = likedSongsLength;
-        });
+        updateSongLikeStatus(_ytid, newValue, songData: widget.song).catchError(
+          (e) {
+            logger.log('Error updating song like status', error: e);
+            _songLikeStatus.value = !newValue;
+          },
+        );
         showToast(
           context,
           newValue


### PR DESCRIPTION
## Summary
- prevent rapid liked song toggles from creating duplicate entries
- centralize liked song and liked playlist count updates in their services
- deduplicate liked songs/playlists by `ytid` before publishing and persisting state
- pass already-loaded song/playlist data into like status updates to avoid unnecessary fallback fetches

## Root cause
Like status updates could be triggered several times before async metadata fetches completed. Each stale completion could append another liked item or manually nudge the count notifier from the UI, leaving the stored list and listeners out of sync.

## Tests
- `flutter analyze`
- `git diff --check`
- manual: rapid like/unlike on liked songs no longer creates duplicate liked song entries
- manual: playlist like/unlike still updates the Library liked playlists section correctly

Note: `flutter test` currently fails on the existing template `test/widget_test.dart` because Hive boxes are not opened before mounting `Musify()`.
