### PR TITLE
Fix content hidden behind floating mini player

### DIFF
--- a/lib/screens/about_page.dart
+++ b/lib/screens/about_page.dart
@@ -25,6 +25,7 @@ import 'package:musify/constants/app_constants.dart';
 import 'package:musify/constants/version.dart';
 import 'package:musify/extensions/l10n.dart';
 import 'package:musify/utilities/url_launcher.dart';
+import 'package:musify/widgets/mini_player_bottom_space.dart';
 
 class AboutPage extends StatelessWidget {
   const AboutPage({super.key});
@@ -159,6 +160,7 @@ class AboutPage extends StatelessWidget {
                 ),
               ),
             ),
+            const MiniPlayerBottomSpace(),
           ],
         ),
       ),

--- a/lib/screens/bottom_navigation_page.dart
+++ b/lib/screens/bottom_navigation_page.dart
@@ -24,6 +24,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:musify/constants/app_constants.dart';
 import 'package:musify/extensions/l10n.dart';
 import 'package:musify/main.dart';
 import 'package:musify/services/settings_manager.dart';
@@ -41,6 +42,10 @@ class BottomNavigationPage extends StatefulWidget {
 }
 
 class _BottomNavigationPageState extends State<BottomNavigationPage> {
+  late final _miniPlayerVisibilityStream = audioHandler.mediaItem
+      .map((mediaItem) => mediaItem != null)
+      .distinct();
+
   bool? _previousOfflineMode;
 
   /// Track the previously selected tab index to detect double-taps on the same tab.
@@ -97,14 +102,16 @@ class _BottomNavigationPageState extends State<BottomNavigationPage> {
                               _onTabTapped(index, items),
                         ),
                       Expanded(
-                        child: StreamBuilder<Object?>(
-                          stream: audioHandler.mediaItem,
+                        child: StreamBuilder<bool>(
+                          initialData: audioHandler.mediaItem.value != null,
+                          stream: _miniPlayerVisibilityStream,
                           builder: (context, snapshot) {
                             final mediaQuery = MediaQuery.of(context);
-                            final bottomPadding = snapshot.data == null
+                            final isMiniPlayerVisible = snapshot.data ?? false;
+                            final bottomPadding = !isMiniPlayerVisible
                                 ? mediaQuery.padding.bottom
                                 : mediaQuery.padding.bottom +
-                                      MiniPlayer.playerHeight;
+                                      miniPlayerTotalHeight;
 
                             return Stack(
                               alignment: Alignment.bottomCenter,

--- a/lib/screens/equalizer_page.dart
+++ b/lib/screens/equalizer_page.dart
@@ -26,6 +26,7 @@ import 'package:musify/constants/app_constants.dart';
 import 'package:musify/extensions/l10n.dart';
 import 'package:musify/main.dart';
 import 'package:musify/services/settings_manager.dart';
+import 'package:musify/widgets/mini_player_bottom_space.dart';
 
 class EqualizerPage extends StatefulWidget {
   const EqualizerPage({super.key});
@@ -427,6 +428,7 @@ class _EqualizerPageState extends State<EqualizerPage> {
                   ),
                 ),
                 const SizedBox(height: 12),
+                const MiniPlayerBottomSpace(),
               ],
             ),
     );

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -31,6 +31,7 @@ import 'package:musify/services/settings_manager.dart';
 import 'package:musify/utilities/app_utils.dart';
 import 'package:musify/utilities/async_loader.dart';
 import 'package:musify/widgets/announcement_box.dart';
+import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/playlist_cube.dart';
 import 'package:musify/widgets/section_header.dart';
 import 'package:musify/widgets/song_bar.dart';
@@ -80,6 +81,7 @@ class _HomePageState extends State<HomePage> {
             _buildSuggestedPlaylists(playlistHeight, showOnlyLiked: true),
             _buildMostPlayedSection(),
             _buildRecommendedSongsSection(),
+            const MiniPlayerBottomSpace(),
           ],
         ),
       ),

--- a/lib/screens/library_page.dart
+++ b/lib/screens/library_page.dart
@@ -38,6 +38,7 @@ import 'package:musify/utilities/offline_playlist_dialogs.dart';
 import 'package:musify/utilities/playlist_dialogs.dart';
 import 'package:musify/utilities/playlist_utils.dart';
 import 'package:musify/widgets/confirmation_dialog.dart';
+import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/playlist_bar.dart';
 import 'package:musify/widgets/section_header.dart';
 
@@ -132,6 +133,7 @@ class _LibraryPageState extends State<LibraryPage> {
                 ..._buildUserPlaylistsSlivers(primaryColor),
                 if (!offlineMode.value)
                   ..._buildLikedPlaylistsSlivers(primaryColor),
+                const SliverMiniPlayerBottomSpace(),
               ],
             ),
           );

--- a/lib/screens/playlist_folder_page.dart
+++ b/lib/screens/playlist_folder_page.dart
@@ -30,6 +30,7 @@ import 'package:musify/utilities/flutter_toast.dart';
 import 'package:musify/utilities/playlist_utils.dart';
 import 'package:musify/widgets/confirmation_dialog.dart';
 import 'package:musify/widgets/dialog_item.dart';
+import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/playlist_bar.dart';
 
 class PlaylistFolderPage extends StatefulWidget {
@@ -171,6 +172,7 @@ class _PlaylistFolderPageState extends State<PlaylistFolderPage> {
                     },
                   ),
                 ),
+              const SliverMiniPlayerBottomSpace(),
             ],
           ),
         );

--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -41,6 +41,7 @@ import 'package:musify/utilities/playlist_utils.dart';
 import 'package:musify/utilities/song_filtering.dart';
 import 'package:musify/utilities/sort_utils.dart';
 import 'package:musify/widgets/edit_playlist_dialog.dart';
+import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/playlist_cube.dart';
 import 'package:musify/widgets/playlist_page/empty_playlist_state.dart';
 import 'package:musify/widgets/playlist_page/playlist_header.dart';
@@ -194,6 +195,7 @@ class _PlaylistPageState extends State<PlaylistPage> {
                   ),
                 ] else
                   EmptyPlaylistState(message: context.l10n!.noSongsInPlaylist),
+                const SliverMiniPlayerBottomSpace(),
               ],
             )
           : SizedBox(

--- a/lib/screens/search_page.dart
+++ b/lib/screens/search_page.dart
@@ -34,6 +34,7 @@ import 'package:musify/utilities/app_utils.dart';
 import 'package:musify/widgets/confirmation_dialog.dart';
 import 'package:musify/widgets/custom_bar.dart';
 import 'package:musify/widgets/custom_search_bar.dart';
+import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/playlist_bar.dart';
 import 'package:musify/widgets/section_title.dart';
 import 'package:musify/widgets/song_bar.dart';
@@ -268,6 +269,7 @@ class _SearchPageState extends State<SearchPage> {
                     )
                   : _buildSearchResults(context, primaryColor),
             ),
+            const MiniPlayerBottomSpace(),
           ],
         ),
       ),

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -42,6 +42,7 @@ import 'package:musify/utilities/url_launcher.dart';
 import 'package:musify/widgets/bottom_sheet_bar.dart';
 import 'package:musify/widgets/confirmation_dialog.dart';
 import 'package:musify/widgets/custom_bar.dart';
+import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/section_header.dart';
 
 class SettingsPage extends StatelessWidget {
@@ -68,6 +69,7 @@ class SettingsPage extends StatelessWidget {
             if (!offlineMode.value) _buildOnlineFeaturesSection(context),
             _buildOthersSection(context),
             const SizedBox(height: 20),
+            const MiniPlayerBottomSpace(),
           ],
         ),
       ),

--- a/lib/screens/user_songs_page.dart
+++ b/lib/screens/user_songs_page.dart
@@ -32,6 +32,7 @@ import 'package:musify/utilities/flutter_toast.dart';
 import 'package:musify/utilities/playlist_utils.dart';
 import 'package:musify/utilities/song_filtering.dart';
 import 'package:musify/widgets/confirmation_dialog.dart';
+import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/playlist_cube.dart';
 import 'package:musify/widgets/playlist_page/empty_playlist_state.dart';
 import 'package:musify/widgets/playlist_page/playlist_header.dart';
@@ -143,6 +144,7 @@ class _UserSongsPageState extends State<UserSongsPage> {
           ),
         ),
         buildSongList(title, songsList, length),
+        const SliverMiniPlayerBottomSpace(),
       ],
     );
   }

--- a/lib/widgets/mini_player_bottom_space.dart
+++ b/lib/widgets/mini_player_bottom_space.dart
@@ -1,0 +1,54 @@
+/*
+ *     Copyright (C) 2026 Valeri Gokadze
+ *
+ *     Musify is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     Musify is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ *     For more information about Musify, including how to contribute,
+ *     please visit: https://github.com/gokadzev/Musify
+ */
+
+import 'package:flutter/material.dart';
+
+/// Adds the current bottom [MediaQuery] padding as scrollable space for the
+/// floating mini player.
+class MiniPlayerBottomSpace extends StatelessWidget {
+  const MiniPlayerBottomSpace({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SafeArea(
+      top: false,
+      left: false,
+      right: false,
+      child: SizedBox.shrink(),
+    );
+  }
+}
+
+/// Adds the current bottom [MediaQuery] padding as sliver scrollable space for
+/// the floating mini player.
+class SliverMiniPlayerBottomSpace extends StatelessWidget {
+  const SliverMiniPlayerBottomSpace({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SliverSafeArea(
+      top: false,
+      left: false,
+      right: false,
+      sliver: SliverToBoxAdapter(child: SizedBox.shrink()),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Fixes scrollable content being hidden behind the floating mini player.

The mini player stays floating and transparent, while affected scrollable pages get enough bottom scroll extent for the last item to move above it.

## Details

- Keeps the mini player in the existing `Stack`, preserving the floating transparent appearance.
- Keeps the single `audioHandler.mediaItem` subscription in `BottomNavigationPage` for the inherited bottom padding used by menus and scroll safe areas.
- Uses shared native `SafeArea` / `SliverSafeArea` constants at the end of affected scroll views instead of custom spacer widgets.
- Uses the full mini-player footprint (`miniPlayerTotalHeight`) so the bottom inset includes the player and floating margin.

## Why this approach

Root-level Scaffold/body padding changes can stop content from painting behind the transparent mini player area. This keeps the visual behavior intact and only extends each scroll view at the end, where the extra space is needed.

This version also avoids per-page listeners and avoids custom inherited/spacer widgets.

## Validation

- `flutter analyze`
- `git diff --check`

`flutter test` still fails on the existing template smoke test because Hive boxes are not opened before `Musify` is pumped (`HiveError: Box not found`). That is unrelated to this UI change.