### PR TITLE
Expand offline song menu tap target

### DIFF
--- a/lib/widgets/song_bar.dart
+++ b/lib/widgets/song_bar.dart
@@ -74,6 +74,8 @@ class SongBar extends StatefulWidget {
 }
 
 class _SongBarState extends State<SongBar> {
+  static const _menuHitAreaWidth = 72.0;
+
   static const likeStatusToIconMapper = {
     true: FluentIcons.heart_off_24_regular,
     false: FluentIcons.heart_24_regular,
@@ -145,23 +147,38 @@ class _SongBarState extends State<SongBar> {
         clipBehavior: Clip.antiAlias,
         child: InkWell(
           onTap: _handleSongTap,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
-            child: Row(
-              children: [
-                _buildAlbumArt(colorScheme),
-                const SizedBox(width: 14),
-                Expanded(
-                  child: _SongInfo(
-                    title: _songTitle,
-                    artist: _songArtist,
-                    plays: _plays,
-                    colorScheme: colorScheme,
-                  ),
+          child: Stack(
+            children: [
+              Padding(
+                padding: const EdgeInsetsDirectional.fromSTEB(
+                  12,
+                  10,
+                  _menuHitAreaWidth,
+                  10,
                 ),
-                _buildActionButtons(context, colorScheme),
-              ],
-            ),
+                child: Row(
+                  children: [
+                    _buildAlbumArt(colorScheme),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: _SongInfo(
+                        title: _songTitle,
+                        artist: _songArtist,
+                        plays: _plays,
+                        colorScheme: colorScheme,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              PositionedDirectional(
+                top: 0,
+                end: 0,
+                bottom: 0,
+                width: _menuHitAreaWidth,
+                child: _buildActionButtons(context, colorScheme),
+              ),
+            ],
           ),
         ),
       ),
@@ -216,19 +233,17 @@ class _SongBarState extends State<SongBar> {
   }
 
   Widget _buildActionButtons(BuildContext context, ColorScheme colorScheme) {
-    return SizedBox(
-      width: 40,
-      height: 40,
+    return PopupMenuButton<String>(
+      borderRadius: BorderRadius.circular(_menuHitAreaWidth / 2),
+      padding: EdgeInsets.zero,
+      splashRadius: 28,
+      onSelected: (value) => _handleMenuAction(context, value),
+      itemBuilder: (context) => _buildMenuItems(context, colorScheme),
       child: Center(
-        child: PopupMenuButton<String>(
-          icon: Icon(
-            FluentIcons.more_vertical_24_regular,
-            color: colorScheme.onSurfaceVariant,
-            size: 20,
-          ),
-          padding: EdgeInsets.zero,
-          onSelected: (value) => _handleMenuAction(context, value),
-          itemBuilder: (context) => _buildMenuItems(context, colorScheme),
+        child: Icon(
+          FluentIcons.more_vertical_24_regular,
+          color: colorScheme.onSurfaceVariant,
+          size: 20,
         ),
       ),
     );
@@ -487,7 +502,10 @@ class _SongBarState extends State<SongBar> {
           value: 'add_to_playlist',
           child: Row(
             children: [
-              Icon(FluentIcons.album_add_24_regular, color: colorScheme.primary),
+              Icon(
+                FluentIcons.album_add_24_regular,
+                color: colorScheme.primary,
+              ),
               const SizedBox(width: 8),
               Text(
                 addToPlaylistText,


### PR DESCRIPTION
## What changed

This expands the trailing three-dot menu hit area for song rows while keeping the visible icon centered and visually consistent.

The `PopupMenuButton` now occupies a full-height trailing area at the end of the row, with the icon centered inside it and a rounded press highlight. This makes the menu easier to press from the offline songs list without turning the feedback into a large rectangular highlight.

## Why

The menu button on offline song rows was hard to tap because the actionable area was only a small 40x40 box inside the row padding. It did not span the full row height or reach the right edge of the row, which made actions like adding a song to the queue frustrating to access.

Partially addresses #843, specifically the note about the offline song row three-dot menu tap target.

## Notes

The hit target width is controlled by `_menuHitAreaWidth` in `SongBar`, currently set to `72.0`. If this feels too large, it should be easy to tune without changing the rest of the implementation.

## Validation

- `flutter analyze`
- `git diff --check`
