### PR TITLE
Fix liked songs state refresh

### DIFF
--- a/lib/services/common_services.dart
+++ b/lib/services/common_services.dart
@@ -252,7 +252,9 @@ Future<void> updateSongLikeStatus(
 
     if (_likedSongIdsAreEqual(userLikedSongsList, updatedLikedSongs)) return;
 
-    userLikedSongsList = updatedLikedSongs;
+    userLikedSongsList
+      ..clear()
+      ..addAll(updatedLikedSongs);
     currentLikedSongsLength.value = userLikedSongsList.length;
     unawaited(addOrUpdateData('user', 'likedSongs', userLikedSongsList));
   } catch (e, stackTrace) {


### PR DESCRIPTION
## Summary
- preserve the existing liked songs list reference when applying deduplicated updates
- keep the liked songs page in sync immediately after removing a song

## Root cause
The liked songs update path started replacing `userLikedSongsList` with a new list after deduplication. Widgets that already held the previous list reference could rebuild from stale data until a larger navigation rebuild happened.

## Validation
- `flutter analyze .`