### PR TITLE
Fix stale offline and liked playlist state

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -92,36 +92,54 @@ class _HomePageState extends State<HomePage> {
     double playlistHeight, {
     bool showOnlyLiked = false,
   }) {
+    if (showOnlyLiked) {
+      return ValueListenableBuilder<List<Map>>(
+        valueListenable: userLikedPlaylists,
+        builder: (_, likedPlaylists, __) => _buildSuggestedPlaylistsSection(
+          playlistHeight,
+          likedPlaylists.take(recommendedCubesNumber).toList(),
+          showOnlyLiked: true,
+        ),
+      );
+    }
+
+    return AsyncLoader<List<dynamic>>(
+      future: getPlaylists(playlistsNum: recommendedCubesNumber),
+      builder: (context, playlists) => _buildSuggestedPlaylistsSection(
+        playlistHeight,
+        playlists,
+      ),
+    );
+  }
+
+  Widget _buildSuggestedPlaylistsSection(
+    double playlistHeight,
+    List<dynamic> playlists, {
+    bool showOnlyLiked = false,
+  }) {
+    if (playlists.isEmpty) return const SizedBox.shrink();
+
     final sectionTitle = showOnlyLiked
         ? context.l10n!.backToFavorites
         : context.l10n!.suggestedPlaylists;
-    return AsyncLoader<List<dynamic>>(
-      future: getPlaylists(
-        playlistsNum: recommendedCubesNumber,
-        onlyLiked: showOnlyLiked,
-      ),
+    final itemsNumber = playlists.length.clamp(0, recommendedCubesNumber);
+    final isLargeScreen = MediaQuery.of(context).size.width > 480;
 
-      builder: (context, playlists) {
-        final itemsNumber = playlists.length.clamp(0, recommendedCubesNumber);
-        final isLargeScreen = MediaQuery.of(context).size.width > 480;
-
-        return Column(
-          children: [
-            SectionHeader(
-              title: sectionTitle,
-              icon: showOnlyLiked
-                  ? FluentIcons.heart_24_filled
-                  : FluentIcons.list_24_filled,
-            ),
-            ConstrainedBox(
-              constraints: BoxConstraints(maxHeight: playlistHeight),
-              child: isLargeScreen
-                  ? _buildHorizontalList(playlists, itemsNumber, playlistHeight)
-                  : _buildCarouselView(playlists, itemsNumber, playlistHeight),
-            ),
-          ],
-        );
-      },
+    return Column(
+      children: [
+        SectionHeader(
+          title: sectionTitle,
+          icon: showOnlyLiked
+              ? FluentIcons.heart_24_filled
+              : FluentIcons.list_24_filled,
+        ),
+        ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: playlistHeight),
+          child: isLargeScreen
+              ? _buildHorizontalList(playlists, itemsNumber, playlistHeight)
+              : _buildCarouselView(playlists, itemsNumber, playlistHeight),
+        ),
+      ],
     );
   }
 

--- a/lib/screens/library_page.dart
+++ b/lib/screens/library_page.dart
@@ -120,7 +120,7 @@ class _LibraryPageState extends State<LibraryPage> {
           userCustomPlaylists,
           userPlaylistFolders,
           offlinePlaylistService.offlinePlaylists,
-          currentLikedPlaylistsLength,
+          userLikedPlaylists,
           onlinePlaylists,
           userPlaylists,
         ]),
@@ -338,7 +338,7 @@ class _LibraryPageState extends State<LibraryPage> {
   }
 
   List<Widget> _buildLikedPlaylistsSlivers(Color primaryColor) {
-    if (userLikedPlaylists.isEmpty) return [];
+    if (userLikedPlaylists.value.isEmpty) return [];
     return [
       SliverToBoxAdapter(
         child: SectionHeader(
@@ -346,7 +346,7 @@ class _LibraryPageState extends State<LibraryPage> {
           icon: FluentIcons.heart_24_filled,
         ),
       ),
-      _buildSliverPlaylistList(userLikedPlaylists),
+      _buildSliverPlaylistList(userLikedPlaylists.value),
     ];
   }
 

--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -76,9 +76,14 @@ class _PlaylistPageState extends State<PlaylistPage> {
   _originalPlaylistList; // Keep original order separately
 
   late final playlistLikeStatus = ValueNotifier<bool>(
-    isPlaylistAlreadyLiked(widget.playlistId),
+    isPlaylistAlreadyLiked(_resolvedPlaylistId),
   );
   bool playlistOfflineStatus = false;
+
+  String? get _resolvedPlaylistId =>
+      _playlist?['ytid']?.toString() ??
+      widget.playlistData?['ytid']?.toString() ??
+      widget.playlistId;
 
   // Sorting
   late PlaylistSortType _sortType = PlaylistSortType.values.firstWhere(
@@ -101,15 +106,25 @@ class _PlaylistPageState extends State<PlaylistPage> {
     super.initState();
     _searchController = TextEditingController();
     _searchFocusNode = FocusNode();
+    userLikedPlaylists.addListener(_syncPlaylistLikeStatus);
     _initializePlaylist();
   }
 
   @override
   void dispose() {
+    userLikedPlaylists.removeListener(_syncPlaylistLikeStatus);
+    playlistLikeStatus.dispose();
     _searchController.dispose();
     _searchFocusNode.dispose();
     _searchQueryNotifier.dispose();
     super.dispose();
+  }
+
+  void _syncPlaylistLikeStatus() {
+    final newStatus = isPlaylistAlreadyLiked(_resolvedPlaylistId);
+    if (playlistLikeStatus.value != newStatus) {
+      playlistLikeStatus.value = newStatus;
+    }
   }
 
   Future<void> _initializePlaylist() async {
@@ -140,6 +155,7 @@ class _PlaylistPageState extends State<PlaylistPage> {
       if (_playlist != null && _playlist['list'] != null) {
         _originalPlaylistList = List<dynamic>.from(_playlist['list'] as List);
         _sortPlaylist(_sortType);
+        _syncPlaylistLikeStatus();
         if (mounted) {
           setState(() {});
         }

--- a/lib/services/common_services.dart
+++ b/lib/services/common_services.dart
@@ -370,7 +370,8 @@ bool isSongAlreadyLiked(songIdToCheck) {
 
 bool isPlaylistAlreadyLiked(playlistIdToCheck) {
   final playlistId = playlistIdToCheck?.toString();
-  return userLikedPlaylists.any(
+  if (playlistId == null || playlistId.isEmpty) return false;
+  return userLikedPlaylists.value.any(
     (playlist) => playlist['ytid']?.toString() == playlistId,
   );
 }

--- a/lib/services/playlists_manager.dart
+++ b/lib/services/playlists_manager.dart
@@ -98,16 +98,8 @@ List<Map> resolvePinnedPlaylists(List<String> ids) {
 
 const pinnedPlaylistsLimit = 5;
 
-final currentLikedPlaylistsLength = ValueNotifier<int>(
-  userLikedPlaylists.value.length,
-);
 var _playlistLikeUpdateToken = 0;
 final _latestPlaylistLikeUpdateTokens = <String, int>{};
-
-void _setUserLikedPlaylists(List<Map> playlists) {
-  userLikedPlaylists.value = List<Map>.from(playlists);
-  currentLikedPlaylistsLength.value = userLikedPlaylists.value.length;
-}
 
 Future<List<dynamic>> getUserPlaylists() async {
   final futures = userPlaylists.value.map((playlistID) async {
@@ -514,8 +506,7 @@ bool _removePlaylistFromFolders(String playlistId) {
 bool _removePlaylistFromLikedPlaylists(String playlistId) {
   final updatedLikedPlaylists = _deduplicateLikedPlaylists(
     userLikedPlaylists.value,
-  )
-    ..removeWhere((playlist) => playlist['ytid']?.toString() == playlistId);
+  )..removeWhere((playlist) => playlist['ytid']?.toString() == playlistId);
 
   if (_likedPlaylistIdsAreEqual(
     userLikedPlaylists.value,
@@ -523,8 +514,7 @@ bool _removePlaylistFromLikedPlaylists(String playlistId) {
   )) {
     return false;
   }
-
-  _setUserLikedPlaylists(updatedLikedPlaylists);
+  userLikedPlaylists.value = List<Map>.from(updatedLikedPlaylists);
   return true;
 }
 
@@ -1211,7 +1201,7 @@ Future<void> updatePlaylistLikeStatus(
       return;
     }
 
-    _setUserLikedPlaylists(updatedLikedPlaylists);
+    userLikedPlaylists.value = List<Map>.from(updatedLikedPlaylists);
     unawaited(
       addOrUpdateData<List>('user', 'likedPlaylists', userLikedPlaylists.value),
     );

--- a/lib/services/playlists_manager.dart
+++ b/lib/services/playlists_manager.dart
@@ -44,8 +44,8 @@ final userPlaylists = ValueNotifier<List<String>>(
 final userCustomPlaylists = ValueNotifier<List<Map>>(
   List<Map>.from(Hive.box('user').get('customPlaylists', defaultValue: [])),
 );
-List<Map> userLikedPlaylists = List<Map>.from(
-  Hive.box('user').get('likedPlaylists', defaultValue: []),
+final userLikedPlaylists = ValueNotifier<List<Map>>(
+  List<Map>.from(Hive.box('user').get('likedPlaylists', defaultValue: [])),
 );
 final userPlaylistFolders = ValueNotifier<List<Map>>(
   List<Map>.from(Hive.box('user').get('playlistFolders', defaultValue: [])),
@@ -71,7 +71,7 @@ Map? _searchAppPlaylistsById(String id) {
       if (p['ytid']?.toString() == id) return p as Map;
     }
   }
-  for (final p in userLikedPlaylists) {
+  for (final p in userLikedPlaylists.value) {
     if (p['ytid']?.toString() == id) return p;
   }
   for (final p in onlinePlaylists.value) {
@@ -99,10 +99,15 @@ List<Map> resolvePinnedPlaylists(List<String> ids) {
 const pinnedPlaylistsLimit = 5;
 
 final currentLikedPlaylistsLength = ValueNotifier<int>(
-  userLikedPlaylists.length,
+  userLikedPlaylists.value.length,
 );
 var _playlistLikeUpdateToken = 0;
 final _latestPlaylistLikeUpdateTokens = <String, int>{};
+
+void _setUserLikedPlaylists(List<Map> playlists) {
+  userLikedPlaylists.value = List<Map>.from(playlists);
+  currentLikedPlaylistsLength.value = userLikedPlaylists.value.length;
+}
 
 Future<List<dynamic>> getUserPlaylists() async {
   final futures = userPlaylists.value.map((playlistID) async {
@@ -402,7 +407,7 @@ void removeUserPlaylist(String playlistId) {
   }
   if (likedChanged) {
     unawaited(
-      addOrUpdateData<List>('user', 'likedPlaylists', userLikedPlaylists),
+      addOrUpdateData<List>('user', 'likedPlaylists', userLikedPlaylists.value),
     );
   }
 }
@@ -466,7 +471,11 @@ void removeUserCustomPlaylist(dynamic playlist) {
     }
     if (likedChanged) {
       unawaited(
-        addOrUpdateData<List>('user', 'likedPlaylists', userLikedPlaylists),
+        addOrUpdateData<List>(
+          'user',
+          'likedPlaylists',
+          userLikedPlaylists.value,
+        ),
       );
     }
   } catch (e, stackTrace) {
@@ -503,15 +512,19 @@ bool _removePlaylistFromFolders(String playlistId) {
 }
 
 bool _removePlaylistFromLikedPlaylists(String playlistId) {
-  final updatedLikedPlaylists = _deduplicateLikedPlaylists(userLikedPlaylists)
+  final updatedLikedPlaylists = _deduplicateLikedPlaylists(
+    userLikedPlaylists.value,
+  )
     ..removeWhere((playlist) => playlist['ytid']?.toString() == playlistId);
 
-  if (_likedPlaylistIdsAreEqual(userLikedPlaylists, updatedLikedPlaylists)) {
+  if (_likedPlaylistIdsAreEqual(
+    userLikedPlaylists.value,
+    updatedLikedPlaylists,
+  )) {
     return false;
   }
 
-  userLikedPlaylists = updatedLikedPlaylists;
-  currentLikedPlaylistsLength.value = userLikedPlaylists.length;
+  _setUserLikedPlaylists(updatedLikedPlaylists);
   return true;
 }
 
@@ -774,9 +787,9 @@ Future<List> getPlaylists({
 }) async {
   if (onlyLiked) {
     if (playlistsNum != null) {
-      return userLikedPlaylists.take(playlistsNum).toList();
+      return userLikedPlaylists.value.take(playlistsNum).toList();
     }
-    return userLikedPlaylists;
+    return userLikedPlaylists.value;
   }
 
   if (playlists.isEmpty || (playlistsNum == null && query == null)) {
@@ -1175,7 +1188,7 @@ Future<void> updatePlaylistLikeStatus(
     }
 
     final updatedLikedPlaylists = _deduplicateLikedPlaylists(
-      userLikedPlaylists,
+      userLikedPlaylists.value,
     );
 
     if (add) {
@@ -1191,14 +1204,16 @@ Future<void> updatePlaylistLikeStatus(
       );
     }
 
-    if (_likedPlaylistIdsAreEqual(userLikedPlaylists, updatedLikedPlaylists)) {
+    if (_likedPlaylistIdsAreEqual(
+      userLikedPlaylists.value,
+      updatedLikedPlaylists,
+    )) {
       return;
     }
 
-    userLikedPlaylists = updatedLikedPlaylists;
-    currentLikedPlaylistsLength.value = userLikedPlaylists.length;
+    _setUserLikedPlaylists(updatedLikedPlaylists);
     unawaited(
-      addOrUpdateData<List>('user', 'likedPlaylists', userLikedPlaylists),
+      addOrUpdateData<List>('user', 'likedPlaylists', userLikedPlaylists.value),
     );
   } catch (e, stackTrace) {
     logger.log(

--- a/lib/widgets/now_playing/bottom_actions_row.dart
+++ b/lib/widgets/now_playing/bottom_actions_row.dart
@@ -62,6 +62,22 @@ class _BottomActionsRowState extends State<BottomActionsRow> {
     _songOfflineStatus = ValueNotifier<bool>(
       isSongAlreadyOffline(widget.audioId),
     );
+    userLikedSongsList.addListener(_syncLikeStatus);
+    userOfflineSongs.addListener(_syncOfflineStatus);
+  }
+
+  void _syncLikeStatus() {
+    final newStatus = isSongAlreadyLiked(widget.audioId);
+    if (_songLikeStatus.value != newStatus) {
+      _songLikeStatus.value = newStatus;
+    }
+  }
+
+  void _syncOfflineStatus() {
+    final newStatus = isSongAlreadyOffline(widget.audioId);
+    if (_songOfflineStatus.value != newStatus) {
+      _songOfflineStatus.value = newStatus;
+    }
   }
 
   @override
@@ -75,6 +91,8 @@ class _BottomActionsRowState extends State<BottomActionsRow> {
 
   @override
   void dispose() {
+    userLikedSongsList.removeListener(_syncLikeStatus);
+    userOfflineSongs.removeListener(_syncOfflineStatus);
     _songLikeStatus.dispose();
     _songOfflineStatus.dispose();
     super.dispose();

--- a/lib/widgets/song_bar.dart
+++ b/lib/widgets/song_bar.dart
@@ -105,12 +105,20 @@ class _SongBarState extends State<SongBar> {
     final isOffline = isSongAlreadyOffline(_ytid);
     _songOfflineStatus = ValueNotifier(isOffline);
     userLikedSongsList.addListener(_syncLikeStatus);
+    userOfflineSongs.addListener(_syncOfflineStatus);
   }
 
   void _syncLikeStatus() {
     final newStatus = isSongAlreadyLiked(_ytid);
     if (_songLikeStatus.value != newStatus) {
       _songLikeStatus.value = newStatus;
+    }
+  }
+
+  void _syncOfflineStatus() {
+    final newStatus = isSongAlreadyOffline(_ytid);
+    if (_songOfflineStatus.value != newStatus) {
+      _songOfflineStatus.value = newStatus;
     }
   }
 
@@ -133,6 +141,7 @@ class _SongBarState extends State<SongBar> {
   @override
   void dispose() {
     userLikedSongsList.removeListener(_syncLikeStatus);
+    userOfflineSongs.removeListener(_syncOfflineStatus);
     _songLikeStatus.dispose();
     _songOfflineStatus.dispose();
     super.dispose();


### PR DESCRIPTION
## Summary

This is a small follow-up to the recent ValueNotifier/reactivity fixes for user song lists. Those commits fixed stale liked-song state by making the source list observable and having widgets sync their local UI state from it. This PR applies the same pattern to two remaining stale-state cases.

## What changed

- Convert `userLikedPlaylists` into a `ValueNotifier<List<Map>>`, while keeping `currentLikedPlaylistsLength` updated for compatibility.
- Update liked-playlist helpers and persistence paths to read/write `userLikedPlaylists.value`.
- Make the home liked-playlists section listen to `userLikedPlaylists`, so it refreshes when playlists are liked/unliked elsewhere and disappears when there are no liked playlists.
- Make `PlaylistPage` listen to `userLikedPlaylists`, so its header heart updates when the same playlist is unliked from the library or another screen.
- Make `SongBar` listen to `userOfflineSongs`, so offline badges/menu state update when a song is removed from offline storage somewhere else.
- Make the now-playing bottom actions listen to liked/offline song list changes, keeping those action buttons in sync with external updates too.

## Why

The affected widgets initialized local `ValueNotifier<bool>` state once, then kept rendering that cached value. After another screen changed the underlying global list, the global data was correct but the still-mounted UI did not recalculate its status.

The recent commits already made `userLikedSongsList`, `userOfflineSongs`, and `userRecentlyPlayed` observable and started fixing in-place mutations. This PR connects the remaining UI surfaces to those observable sources, and does the same for liked playlists.

## Validation

- `flutter analyze`
- `flutter build apk --debug --flavor github`

Note: I did not include the separate home `Most Played` scroll-jump issue here; that should be handled independently because the attempted quick fix did not solve it cleanly.