### PR TITLE
Fix automatic song picker autoplay

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -787,6 +787,13 @@ class MusifyAudioHandler extends BaseAudioHandler {
       }
 
       final insertIndex = _queueList.length;
+      final shouldPlayInsertedSong =
+          playNextSongAutomatically.value &&
+          !sleepTimerExpired &&
+          _currentLoadingIndex == -1 &&
+          audioPlayer.processingState == ProcessingState.completed &&
+          _queueList.isNotEmpty &&
+          _currentQueueIndex == _queueList.length - 1;
       final queueSong = _queueEntryIds.createSong(song);
       queueSong['isAutoPicked'] = true;
       _queueList.insert(insertIndex, queueSong);
@@ -798,7 +805,9 @@ class MusifyAudioHandler extends BaseAudioHandler {
       _updateQueueMediaItems();
       _cleanupOldPreloadedSongs();
 
-      if (!audioPlayer.playing && _queueList.length == 1) {
+      if (shouldPlayInsertedSong) {
+        await _playFromQueue(insertIndex);
+      } else if (!audioPlayer.playing && _queueList.length == 1) {
         await _playFromQueue(0);
       }
     } catch (e, stackTrace) {


### PR DESCRIPTION
## Summary
- Play an auto-picked recommendation immediately if it arrives after the current track already completed at the end of the queue.
- Preserve the existing path when the recommendation arrives before completion or when playback has already moved elsewhere.

## Root cause
The automatic song picker fetches recommendations asynchronously. If the fetch finishes after the last queued track has completed, the recommendation is inserted into the queue, but no new completion event fires to advance playback to it.

## Testing
- flutter analyze
- flutter test (fails before exercising this change because test/widget_test.dart is still the default counter smoke test and the app starts without opening Hive boxes)