### PR TITLE
Keep current song when clearing queue

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -1052,13 +1052,25 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
   void clearQueue() {
     try {
+      final currentSong = _currentQueueIndex >= 0 &&
+              _currentQueueIndex < _queueList.length
+          ? cloneMap(_queueList[_currentQueueIndex])
+          : null;
+
       _queueList.clear();
       _originalQueueList.clear();
+
+      if (currentSong != null) {
+        _queueList.add(currentSong);
+        _originalQueueList.add(cloneMap(currentSong));
+      }
+
       _currentQueueIndex = 0;
       _currentLoadingIndex = -1;
       _currentLoadingTransitionId = -1;
       _resetPreloadingState();
       _updateQueueMediaItems();
+      _updatePlaybackState();
     } catch (e, stackTrace) {
       logger.log('Error clearing queue', error: e, stackTrace: stackTrace);
     }


### PR DESCRIPTION
What changed
- Clear queue now preserves the currently playing track instead of emptying the queue entirely.
- Playback state is refreshed after the clear so the queue index stays aligned with the actual track that is still playing.

Why
- The old behavior removed every item and reset the queue index, which made the next song added look like the active track even though the previous song was still playing.

Impact
- After Clear queue, the player keeps showing the real current song.
- New queue additions append after that track instead of stealing the active slot.

Checks
- `flutter analyze lib/services/audio_service.dart`
- `flutter test test/widget_test.dart` (fails in the existing app smoke test because Hive boxes are not opened there)