### PR TITLE
feat: add end-of-song option to sleep timer

### DIFF
--- a/lib/localization/app_de.arb
+++ b/lib/localization/app_de.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "Sleep-Timer abgebrochen",
   "sleepTimerSet": "Sleep-Timer",
+  "endOfSong": "Ende des Songs",
   "songAdded": "Song erfolgreich hinzugefügt",
   "songAddedToOffline": "Song ist jetzt offline verfügbar",
   "songAlreadyInPlaylist": "Song ist bereits in der Playlist",

--- a/lib/localization/app_el.arb
+++ b/lib/localization/app_el.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "Ο χρονοδιακόπτης ύπνου ακυρώθηκε",
   "sleepTimerSet": "Ρύθμιση χρονοδιακόπτη ύπνου",
+  "endOfSong": "Τέλος τραγουδιού",
   "songAdded": "Το τραγούδι προστέθηκε με επιτυχία!",
   "songAddedToOffline": "Το τραγούδι είναι τώρα διαθέσιμο εκτός σύνδεσης",
   "songAlreadyInPlaylist": "Το τραγούδι είναι ήδη στη λίστα αναπαραγωγής",

--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -216,6 +216,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "Sleep timer cancelled",
   "sleepTimerSet": "Sleep timer set",
+  "endOfSong": "End of song",
   "songAdded": "Song added",
   "songAddedToOffline": "Song is now available offline",
   "songAlreadyInPlaylist": "Song is already in the playlist",

--- a/lib/localization/app_es.arb
+++ b/lib/localization/app_es.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Temporizador de apagado",
   "sleepTimerCancelled": "Temporizador de apagado cancelado",
   "sleepTimerSet": "Temporizador de apagado programado",
+  "endOfSong": "Fin de canción",
   "songAdded": "Canción añadida",
   "songAddedToOffline": "La canción ya está disponible sin conexión",
   "songAlreadyInPlaylist": "La canción ya está en la lista de reproducción",

--- a/lib/localization/app_et.arb
+++ b/lib/localization/app_et.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "Unetaimer tühistatud",
   "sleepTimerSet": "Unetaimer seatud",
+  "endOfSong": "Laulu lõpp",
   "songAdded": "Laul lisatud",
   "songAddedToOffline": "Laul on nüüd saadaval ilma võrguühenduseta",
   "songAlreadyInPlaylist": "Laul on juba nimekirjas",

--- a/lib/localization/app_fr.arb
+++ b/lib/localization/app_fr.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Minuterie de mise en veille",
   "sleepTimerCancelled": "Minuterie de sommeil annulée",
   "sleepTimerSet": "Minuterie de sommeil réglée",
+  "endOfSong": "Fin du morceau",
   "songAdded": "Titre ajouté avec succès !",
   "songAddedToOffline": "Le titre est désormais disponible hors ligne",
   "songAlreadyInPlaylist": "Le titre est déjà dans la playlist",

--- a/lib/localization/app_he.arb
+++ b/lib/localization/app_he.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "טיימר שינה בוטל",
   "sleepTimerSet": "טיימר שינה הוגדר",
+  "endOfSong": "סוף השיר",
   "songAdded": "השיר נוסף",
   "songAddedToOffline": "השיר זמין עכשיו במצב לא מקוון",
   "songAlreadyInPlaylist": "השיר כבר נמצא ברשימת ההשמעה",

--- a/lib/localization/app_hi.arb
+++ b/lib/localization/app_hi.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "Sleep timer cancelled",
   "sleepTimerSet": "Sleep timer set",
+  "endOfSong": "गाने का अंत",
   "songAdded": "गाना जोड़ा गया",
   "songAddedToOffline": "गाना अब ऑफ़लाइन उपलब्ध है",
   "songAlreadyInPlaylist": "गाना पहले से ही प्लेलिस्ट में है",

--- a/lib/localization/app_hu.arb
+++ b/lib/localization/app_hu.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "Elalvás időzítő törölve",
   "sleepTimerSet": "Elalvás időzítő beállítva",
+  "endOfSong": "Dal vége",
   "songAdded": "Zene hozzáadva",
   "songAddedToOffline": "Zene már elérhető Offline ",
   "songAlreadyInPlaylist": "Zene már megtalálható a lejátszási listán",

--- a/lib/localization/app_id.arb
+++ b/lib/localization/app_id.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Pewaktu tidur",
   "sleepTimerCancelled": "Pewaktu tidur dibatalkan",
   "sleepTimerSet": "Pewaktu tidur diatur",
+  "endOfSong": "Akhir lagu",
   "songAdded": "Lagu berhasil ditambahkan",
   "songAddedToOffline": "Lagu ini sekarang tersedia secara offline",
   "songAlreadyInPlaylist": "Lagu sudah ada dalam daftar putar",

--- a/lib/localization/app_it.arb
+++ b/lib/localization/app_it.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Timer di spegnimento",
   "sleepTimerCancelled": "Timer di sospensione annullato",
   "sleepTimerSet": "Timer di spegnimento impostato",
+  "endOfSong": "Fine del brano",
   "songAdded": "Brano aggiunto con successo",
   "songAddedToOffline": "Il brano è ora disponibile offline",
   "songAlreadyInPlaylist": "Il brano è già contenuto nella playlist",

--- a/lib/localization/app_ja.arb
+++ b/lib/localization/app_ja.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "スリープタイマーをキャンセルしました",
   "sleepTimerSet": "スリープタイマーを設定",
+  "endOfSong": "曲の終わり",
   "songAdded": "曲を追加しました",
   "songAddedToOffline": "曲がオフラインで利用可能になりました",
   "songAlreadyInPlaylist": "曲は既に再生リストに含まれます",

--- a/lib/localization/app_ko.arb
+++ b/lib/localization/app_ko.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "취침 타이머",
   "sleepTimerCancelled": "수면 타이머가 취소되었음",
   "sleepTimerSet": "수면 타이머가 설정되었음",
+  "endOfSong": "곡 끝",
   "songAdded": "노래가 추가되었음",
   "songAddedToOffline": "이제 노래는 오프라인에서 사용할 수 있음",
   "songAlreadyInPlaylist": "노래가 이미 재생목록에 있음",

--- a/lib/localization/app_pl.arb
+++ b/lib/localization/app_pl.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "Wyłącznik czasowy został anulowany",
   "sleepTimerSet": "Czas uśpienia ustawiony",
+  "endOfSong": "Koniec utworu",
   "songAdded": "Utwór pomyślnie dodany!",
   "songAddedToOffline": "Utwór jest teraz dostępny w trybie offline",
   "songAlreadyInPlaylist": "Utwór jest już na liście odtwarzania",

--- a/lib/localization/app_pt.arb
+++ b/lib/localization/app_pt.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Timer",
   "sleepTimerCancelled": "Timer cancelado",
   "sleepTimerSet": "Timer ativado",
+  "endOfSong": "Fim da faixa",
   "songAdded": "Música adicionada",
   "songAddedToOffline": "Música está disponível offline",
   "songAlreadyInPlaylist": "Esta música já está na playlist",

--- a/lib/localization/app_ru.arb
+++ b/lib/localization/app_ru.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Таймер сна",
   "sleepTimerCancelled": "Таймер сна отменен",
   "sleepTimerSet": "Таймер сна установлен",
+  "endOfSong": "Конец песни",
   "songAdded": "Песню добавлено",
   "songAddedToOffline": "Песня теперь доступна офлайн",
   "songAlreadyInPlaylist": "Песня уже в плейлисте",

--- a/lib/localization/app_sv.arb
+++ b/lib/localization/app_sv.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "Insomningstimern avbruten",
   "sleepTimerSet": "Insomningstimern inställd",
+  "endOfSong": "Låtens slut",
   "songAdded": "Låt tillagd",
   "songAddedToOffline": "Låten är nu tillgänglig offline",
   "songAlreadyInPlaylist": "Låten finns redan i spellistan",

--- a/lib/localization/app_ta.arb
+++ b/lib/localization/app_ta.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Sleep timer",
   "sleepTimerCancelled": "உறக்க டைமர் ரத்து செய்யப்பட்டது",
   "sleepTimerSet": "உறக்க டைமர் அமைக்கப்பட்டது",
+  "endOfSong": "பாடலின் முடிவு",
   "songAdded": "பாடல் சேர்க்கப்பட்டது",
   "songAddedToOffline": "பாடல் இப்போது ஆஃப்லைனில் கிடைக்கிறது",
   "songAlreadyInPlaylist": "பாடல் ஏற்கனவே பிளேலிஸ்டில் உள்ளது",

--- a/lib/localization/app_tr.arb
+++ b/lib/localization/app_tr.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Uyku zamanlayıcısı",
   "sleepTimerCancelled": "Uyku zamanlayıcısı iptal edildi",
   "sleepTimerSet": "Uyku zamanlayıcısı ayarlandı",
+  "endOfSong": "Parça sonu",
   "songAdded": "Parça Eklendi",
   "songAddedToOffline": "Parça artık çevrim dışında kullanılabilir",
   "songAlreadyInPlaylist": "Bu parça zaten listede var",

--- a/lib/localization/app_uk.arb
+++ b/lib/localization/app_uk.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "Таймер сну",
   "sleepTimerCancelled": "Таймер сну скасовано",
   "sleepTimerSet": "Таймер сну встановлено",
+  "endOfSong": "Кінець пісні",
   "songAdded": "Пісню додано",
   "songAddedToOffline": "Пісня тепер доступна офлайн",
   "songAlreadyInPlaylist": "Пісня вже в плейлисті",

--- a/lib/localization/app_zh.arb
+++ b/lib/localization/app_zh.arb
@@ -214,6 +214,7 @@
   "sleepTimer": "睡眠定时器",
   "sleepTimerCancelled": "睡眠定时器已取消",
   "sleepTimerSet": "睡眠定时器已设置",
+  "endOfSong": "歌曲结束",
   "songAdded": "歌曲已添加",
   "songAddedToOffline": "歌曲现已离线可用",
   "songAlreadyInPlaylist": "歌曲已在播放列表中",

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -72,6 +72,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
   Timer? _sleepTimer;
   Timer? _debounceTimer;
   bool sleepTimerExpired = false;
+  bool sleepTimerEndOfSong = false;
 
   final List<Map> _queueList = [];
   final List<Map> _originalQueueList = [];
@@ -585,6 +586,14 @@ class MusifyAudioHandler extends BaseAudioHandler {
   void _handleProcessingStateChange(ProcessingState state) {
     try {
       if (state == ProcessingState.completed) {
+        if (sleepTimerEndOfSong) {
+          sleepTimerExpired = true;
+          sleepTimerEndOfSong = false;
+          stop();
+          sleepTimerNotifier.value = null;
+          return;
+        }
+        
         if (!sleepTimerExpired && !_completionEventPending) {
           _completionEventPending = true;
 
@@ -612,6 +621,13 @@ class MusifyAudioHandler extends BaseAudioHandler {
       } else if (state == ProcessingState.ready) {
         _completionEventPending = false;
         _completionHandlerLoadStarted = false;
+
+        // Clear the expired flag so future song completions are not
+        // blocked after a sleep timer fired in a previous session.
+        // Do NOT touch sleepTimerEndOfSong here — 'ready' fires not
+        // only for new songs but also on buffering recovery within the
+        // same song, which would cancel an active "end of song" timer.
+        sleepTimerExpired = false;
       }
     } catch (e, stackTrace) {
       logger.log(
@@ -2237,8 +2253,8 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
       _sleepTimer = Timer(duration, () async {
         sleepTimerExpired = true;
-        await pause();
-        sleepTimerNotifier.value = Duration.zero;
+        await stop();
+        sleepTimerNotifier.value = null;
       });
     } catch (e, stackTrace) {
       logger.log('Error setting sleep timer', error: e, stackTrace: stackTrace);
@@ -2250,10 +2266,26 @@ class MusifyAudioHandler extends BaseAudioHandler {
       _sleepTimer?.cancel();
       _sleepTimer = null;
       sleepTimerExpired = false;
+      sleepTimerEndOfSong = false;
       sleepTimerNotifier.value = Duration.zero;
     } catch (e, stackTrace) {
       logger.log(
         'Error canceling sleep timer',
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> setSleepTimerEndOfSong() async {
+    try {
+      _sleepTimer?.cancel();
+      sleepTimerExpired = false;
+      sleepTimerEndOfSong = true;
+      sleepTimerNotifier.value = const Duration(milliseconds: -1);
+    } catch (e, stackTrace) {
+      logger.log(
+        'Error setting sleep timer end of song',
         error: e,
         stackTrace: stackTrace,
       );

--- a/lib/widgets/now_playing/bottom_actions_row.dart
+++ b/lib/widgets/now_playing/bottom_actions_row.dart
@@ -396,9 +396,28 @@ void _showSleepTimerDialog(BuildContext context) {
                   spacing: 8,
                   runSpacing: 8,
                   alignment: WrapAlignment.center,
-                  children: [15, 30, 45, 60].map((mins) {
-                    return ActionChip(
-                      label: Text('$mins min'),
+                  children: [
+                    ...[15, 30, 45, 60].map((mins) {
+                      return ActionChip(
+                        label: Text('$mins min'),
+                        backgroundColor: colorScheme.surfaceContainerHighest,
+                        labelStyle: TextStyle(
+                          color: colorScheme.onSurfaceVariant,
+                          fontSize: 12,
+                        ),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        onPressed: () {
+                          setState(() {
+                            hours = mins ~/ 60;
+                            minutes = mins % 60;
+                          });
+                        },
+                      );
+                    }),
+                    ActionChip(
+                      label: Text(context.l10n!.endOfSong),
                       backgroundColor: colorScheme.surfaceContainerHighest,
                       labelStyle: TextStyle(
                         color: colorScheme.onSurfaceVariant,
@@ -408,13 +427,16 @@ void _showSleepTimerDialog(BuildContext context) {
                         borderRadius: BorderRadius.circular(12),
                       ),
                       onPressed: () {
-                        setState(() {
-                          hours = mins ~/ 60;
-                          minutes = mins % 60;
-                        });
+                        audioHandler.setSleepTimerEndOfSong();
+                        showToast(
+                          context,
+                          context.l10n!.sleepTimerSet,
+                          duration: const Duration(seconds: 1, milliseconds: 500),
+                        );
+                        Navigator.pop(context);
                       },
-                    );
-                  }).toList(),
+                    ),
+                  ],
                 ),
               ],
             ),


### PR DESCRIPTION
### Summary

Adds an "End of song" option to the sleep timer. Instead of stopping after a fixed duration, the timer now stops playback when the current song finishes.

### What changed

- New `sleepTimerEndOfSong` flag and `setSleepTimerEndOfSong()` method in `MusifyAudioHandler`
- Detects song completion in `_handleProcessingStateChange` and stops playback when the flag is active
- New "End of song" chip in the sleep timer dialog
- Regular sleep timer now uses `stop()` instead of `pause()` for consistent behavior across both modes
- Fixed: sleep timer button no longer stays highlighted after expiration (`Duration.zero` → `null`)
- Fixed: `sleepTimerExpired` is reset on `ProcessingState.ready`, so auto-advance works if the user resumes playback after the timer fired
- Localized in 21 languages

### Screenshots
<img width="488" height="1084" alt="Screenshot" src="https://github.com/user-attachments/assets/bad2c02b-56a6-4100-a9bd-13434e7c5a5e" />