### PR TITLE
fix: frame low-res queue thumbnails without black letterbox bars

### DIFF
--- a/lib/widgets/queue_list_view.dart
+++ b/lib/widgets/queue_list_view.dart
@@ -511,13 +511,24 @@ class _ArtworkThumbnail extends StatelessWidget {
     }
     final imageUrl = song['lowResImage']?.toString() ?? '';
     if (imageUrl.isEmpty) return _fallback();
+    // Low-res YouTube 'default.jpg' thumbnails ship with baked-in black
+    // letterbox bars, so BoxFit.cover keeps them visible. Detect that case and
+    // stretch over the bars with fill + centerSlice, otherwise crop with cover —
+    // matching SongBar so the queue frames covers the same way (no black bars).
+    final isImageSmall = imageUrl.contains('default.jpg');
     return CachedNetworkImage(
       width: size,
       height: size,
       imageUrl: imageUrl,
       imageBuilder: (_, imageProvider) => ClipRRect(
         borderRadius: BorderRadius.circular(radius),
-        child: Image(image: imageProvider, fit: BoxFit.cover),
+        child: Image(
+          image: imageProvider,
+          width: size,
+          height: size,
+          fit: isImageSmall ? BoxFit.fill : BoxFit.cover,
+          centerSlice: isImageSmall ? const Rect.fromLTRB(1, 1, 1, 1) : null,
+        ),
       ),
       placeholder: (_, __) => _loading(),
       errorWidget: (_, __, ___) => _fallback(),


### PR DESCRIPTION
Queue tiles render `lowResImage`, which for YouTube is often the `default.jpg` thumbnail that ships with baked-in black letterbox bars. BoxFit.cover keeps those bars visible, so some tiles showed black borders while the same songs are framed correctly in the now-playing SongBar.

Mirror SongBar's artwork handling: when the URL is the small `default.jpg` thumbnail, stretch over the bars with BoxFit.fill + a 1px centerSlice; otherwise keep BoxFit.cover. Also size the imageBuilder's Image explicitly so it stays constrained to the tile.