### PR TITLE
fix: mark related playlists/albums offline when songs are downloaded via another playlist

### DIFF
--- a/lib/services/playlist_download_service.dart
+++ b/lib/services/playlist_download_service.dart
@@ -176,6 +176,29 @@ class OfflinePlaylistService {
           updatedPlaylists.add(offlinePlaylist);
         }
 
+        // Also mark albums/playlists whose songs are now fully offline
+        final offlineSongIds = userOfflineSongs.value
+            .map((s) => s['ytid'])
+            .toSet();
+        for (final p in playlists) {
+          final pList = p['list'] as List?;
+          if (pList == null ||
+              pList.isEmpty ||
+              p['ytid'] == playlistId ||
+              isPlaylistDownloaded(
+                p['ytid']?.toString() ?? '',
+              )) {
+            continue;
+          }
+          if (pList.every((s) => offlineSongIds.contains(s['ytid']))) {
+            updatedPlaylists.add({
+              ...p,
+              'list': pList,
+              'downloadedAt': DateTime.now().millisecondsSinceEpoch,
+            });
+          }
+        }
+
         offlinePlaylists.value = updatedPlaylists;
         unawaited(
           addOrUpdateData<List>(


### PR DESCRIPTION
## Problem

When downloading a playlist, only that playlist was marked as offline in `offlinePlaylists`. However, if another entity (e.g. an album from the DB) shares the same songs and all of them are now downloaded, that entity still won't appear in the "Offline Playlists" section when the user goes to offline mode.

Example scenario:
1. User has an album A and a custom playlist P
2. User adds album A's songs into playlist P (without downloading the album)
3. User downloads playlist P → all songs are now in `userOfflineSongs`, playlist P is in `offlinePlaylists`
4. Album A shows the downloaded icon (because `isPlaylistFullyOffline` returns true)
5. But album A does NOT appear in the offline playlists section, because it was never added to `offlinePlaylists`
6. In offline mode, the user can't access album A even though all its songs are available locally

## Solution

After a playlist download completes, scan the global `playlists` list (which includes `playlistsDB` and `albumsDB`) for any entities that:
- Have their songs already loaded (`list` is non-empty)
- Are not already in `offlinePlaylists`
- Are now fully offline (all song IDs are in `userOfflineSongs`)

If an entity meets all conditions, add it to `offlinePlaylists` so it appears in the offline library section.

This handles the case where an album/playlist's songs were downloaded indirectly (via another playlist) and ensures consistency between the download icon and the actual offline availability.
