### PR TITLE
enhancement: cache SponsorBlock segments for offline playback

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -2248,7 +2248,14 @@ class MusifyAudioHandler extends BaseAudioHandler {
       final tag = mapToMediaItem(song);
 
       if (isOffline) {
-        return AudioSource.file(songUrl, tag: tag);
+        final fileSource = AudioSource.file(songUrl, tag: tag);
+
+        if (sponsorBlockSupport.value) {
+          return _applyOfflineSponsorBlock(fileSource, song['ytid']) ??
+              fileSource;
+        }
+
+        return fileSource;
       }
 
       final uri = Uri.parse(songUrl);
@@ -2273,6 +2280,22 @@ class MusifyAudioHandler extends BaseAudioHandler {
     }
   }
 
+  AudioSource? _applyOfflineSponsorBlock(
+    UriAudioSource audioSource,
+    String songId,
+  ) {
+    final segments = getCachedSponsorBlockSegments(songId);
+    if (segments != null) {
+      return segments.isEmpty
+          ? null
+          : _buildSkippedAudioSource(audioSource, segments);
+    }
+    // Nothing stored yet, e.g. a song downloaded before this existed: look it
+    // up now so the next playback of it skips offline too.
+    if (!offlineMode.value) unawaited(cacheSponsorBlockSegments(songId));
+    return null;
+  }
+
   Future<AudioSource?> checkIfSponsorBlockIsAvailable(
     UriAudioSource audioSource,
     String songId,
@@ -2280,49 +2303,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
     try {
       final segments = await getSkipSegments(songId);
       if (segments.isEmpty) return null;
-
-      // Sort segments by start time
-      segments.sort((a, b) => (a['start'] ?? 0).compareTo(b['start'] ?? 0));
-
-      final children = <AudioSource>[];
-      var lastEnd = 0;
-
-      for (final segment in segments) {
-        final start = segment['start'] ?? 0;
-        final end = segment['end'] ?? 0;
-
-        // Add the "good" part before this sponsor segment
-        if (start > lastEnd) {
-          children.add(
-            ClippingAudioSource(
-              child: audioSource,
-              start: Duration(seconds: lastEnd),
-              end: Duration(seconds: start),
-            ),
-          );
-        }
-
-        // Advance lastEnd, handling overlapping segments
-        if (end > lastEnd) {
-          lastEnd = end;
-        }
-      }
-
-      // Add the final part from the last sponsor segment to the end of the song
-      children.add(
-        ClippingAudioSource(
-          child: audioSource,
-          start: Duration(seconds: lastEnd),
-          // end: null means play until the end of the file
-        ),
-      );
-
-      if (children.length == 1) {
-        return children.first;
-      }
-
-      // ignore: deprecated_member_use
-      return ConcatenatingAudioSource(children: children);
+      return _buildSkippedAudioSource(audioSource, segments);
     } catch (e, stackTrace) {
       logger.log(
         'Error checking sponsor block',
@@ -2331,6 +2312,38 @@ class MusifyAudioHandler extends BaseAudioHandler {
       );
       return null;
     }
+  }
+
+  static AudioSource? _buildSkippedAudioSource(
+    UriAudioSource source,
+    List<Map<String, int>> segments,
+  ) {
+    segments.sort((a, b) => (a['start'] ?? 0).compareTo(b['start'] ?? 0));
+    final children = <AudioSource>[];
+    var lastEnd = 0;
+    for (final segment in segments) {
+      final start = segment['start'] ?? 0;
+      final end = segment['end'] ?? 0;
+      if (start > lastEnd) {
+        children.add(
+          ClippingAudioSource(
+            child: source,
+            start: Duration(seconds: lastEnd),
+            end: Duration(seconds: start),
+          ),
+        );
+      }
+      if (end > lastEnd) lastEnd = end;
+    }
+    children.add(
+      ClippingAudioSource(
+        child: source,
+        start: Duration(seconds: lastEnd),
+      ),
+    );
+    if (children.length == 1) return children.first;
+    // ignore: deprecated_member_use
+    return ConcatenatingAudioSource(children: children);
   }
 
   Future<void> skipToSong(int newIndex) async {

--- a/lib/services/common_services.dart
+++ b/lib/services/common_services.dart
@@ -489,39 +489,51 @@ Future<List<String>> getSearchSuggestions(String query) async {
   return suggestions;
 }
 
+// Throws on network, HTTP and parsing failure instead of swallowing it, so
+// callers that need to tell "confirmed no segments" apart from "failed to
+// fetch" (e.g. the offline cache, which must not persist a false negative)
+// can do so.
+Future<List<Map<String, int>>> _fetchSkipSegments(String id) async {
+  final res = await ProxyManager().getProxiedResponse(
+    Uri(
+      scheme: 'https',
+      host: 'sponsor.ajay.app',
+      path: '/api/skipSegments',
+      queryParameters: {
+        'videoID': id,
+        'category': [
+          'sponsor',
+          'selfpromo',
+          'interaction',
+          'intro',
+          'outro',
+          'music_offtopic',
+        ],
+        'actionType': 'skip',
+      },
+    ),
+  );
+  // 404 is how the API answers "this video has no segments", so it is a real
+  // empty result and safe to remember. Any other non-200 is a failure, and
+  // throwing keeps it from being stored as a confirmed "no segments".
+  if (res.statusCode == 404 || res.body == 'Not Found') return [];
+  if (res.statusCode != 200) {
+    throw HttpException('SponsorBlock responded ${res.statusCode} for $id');
+  }
+
+  final data = jsonDecode(res.body);
+  final segments = data.map((obj) {
+    return Map.castFrom<String, dynamic, String, int>({
+      'start': obj['segment'].first.toInt(),
+      'end': obj['segment'].last.toInt(),
+    });
+  }).toList();
+  return List.castFrom<dynamic, Map<String, int>>(segments);
+}
+
 Future<List<Map<String, int>>> getSkipSegments(String id) async {
   try {
-    final res = await ProxyManager().getProxiedResponse(
-      Uri(
-        scheme: 'https',
-        host: 'sponsor.ajay.app',
-        path: '/api/skipSegments',
-        queryParameters: {
-          'videoID': id,
-          'category': [
-            'sponsor',
-            'selfpromo',
-            'interaction',
-            'intro',
-            'outro',
-            'music_offtopic',
-          ],
-          'actionType': 'skip',
-        },
-      ),
-    );
-    if (res.statusCode == 200 && res.body != 'Not Found') {
-      final data = jsonDecode(res.body);
-      final segments = data.map((obj) {
-        return Map.castFrom<String, dynamic, String, int>({
-          'start': obj['segment'].first.toInt(),
-          'end': obj['segment'].last.toInt(),
-        });
-      }).toList();
-      return List.castFrom<dynamic, Map<String, int>>(segments);
-    } else {
-      return [];
-    }
+    return await _fetchSkipSegments(id);
   } catch (e, stackTrace) {
     logger.log('Error in getSkipSegments', error: e, stackTrace: stackTrace);
     return [];
@@ -675,6 +687,7 @@ Future<bool> makeSongOffline(dynamic song) async {
     if (isSongAlreadyOffline(ytid)) {
       final existingPath = FilePaths.getAudioPath(ytid);
       if (await File(existingPath).exists()) {
+        unawaited(cacheSponsorBlockSegments(ytid));
         return true;
       }
     }
@@ -761,6 +774,8 @@ Future<bool> makeSongOffline(dynamic song) async {
           userOfflineSongs.value,
         ),
       );
+
+      unawaited(cacheSponsorBlockSegments(ytid));
     } catch (e, st) {
       logger.log(
         'Error updating global offline songs list',
@@ -826,6 +841,81 @@ Future<bool> removeSongFromOffline(dynamic songId) async {
     );
     return false;
   }
+}
+
+const _sponsorCallSpacing = Duration(seconds: 1);
+Future<void> _sponsorSerialChain = Future.value();
+
+/// Runs SponsorBlock lookups one at a time, spaced out, so that a playlist
+/// download finishing several songs at once does not fire them all together.
+Future<T> _sponsorSerialCall<T>(Future<T> Function() action) {
+  final result = _sponsorSerialChain.then((_) => action());
+  _sponsorSerialChain = result
+      .then((_) {}, onError: (_) {})
+      .then((_) => Future<void>.delayed(_sponsorCallSpacing));
+  return result;
+}
+
+/// Stores the SponsorBlock segments of a downloaded song next to the download
+/// itself, so they last exactly as long as it does: they are not backed up,
+/// they never expire, and removing the song removes them.
+///
+/// Looked up once per song: a stored result — including a confirmed empty one —
+/// is never fetched again.
+Future<void> cacheSponsorBlockSegments(String ytid) async {
+  try {
+    if (getOfflineSongByYtid(ytid)['sponsorSegments'] != null) return;
+
+    // Two attempts, spaced out by the queue above; a failure stores nothing so
+    // it is not mistaken for a confirmed "no segments", and is looked up again
+    // the next time the song plays.
+    for (var attempt = 0; attempt < 2; attempt++) {
+      try {
+        final segments = await _sponsorSerialCall(
+          () => _fetchSkipSegments(ytid),
+        );
+        await _storeSponsorBlockSegments(ytid, segments);
+        return;
+      } catch (_) {
+        continue;
+      }
+    }
+  } catch (e, stackTrace) {
+    logger.log(
+      'Error caching sponsor block for $ytid',
+      error: e,
+      stackTrace: stackTrace,
+    );
+  }
+}
+
+Future<void> _storeSponsorBlockSegments(
+  String ytid,
+  List<Map<String, int>> segments,
+) async {
+  final index = userOfflineSongs.value.indexWhere((s) => s['ytid'] == ytid);
+  // The song was removed while the lookup was in flight.
+  if (index == -1) return;
+
+  final updatedOfflineSongs = List.from(userOfflineSongs.value);
+  updatedOfflineSongs[index] = {
+    ...Map<String, dynamic>.from(updatedOfflineSongs[index] as Map),
+    'sponsorSegments': segments,
+  };
+  userOfflineSongs.value = updatedOfflineSongs;
+  await addOrUpdateData<List>(
+    'userNoBackup',
+    'offlineSongs',
+    userOfflineSongs.value,
+  );
+}
+
+/// The stored segments of a downloaded song, or null when it has none stored
+/// yet. An empty list means the song was looked up and has no segments.
+List<Map<String, int>>? getCachedSponsorBlockSegments(String ytid) {
+  final stored = getOfflineSongByYtid(ytid)['sponsorSegments'];
+  if (stored is! List) return null;
+  return [for (final segment in stored) Map<String, int>.from(segment as Map)];
 }
 
 Future<File?> _downloadAndSaveArtworkFile(String url, String filePath) async {


### PR DESCRIPTION
When a song is downloaded for offline playback, SponsorBlock segments are lost — the app stops making HTTP requests offline, so skip segments are never applied.

This PR stores the SponsorBlock segments of a song at download time and reads them back during offline playback, so offline songs still respect SponsorBlock skips. Songs downloaded before this existed are looked up lazily on their first offline play (when online).

### Where the segments live

They are stored inside the song's own record in the `userNoBackup` box, right next to `audioPath`, so they last exactly as long as the download does: they are not backed up, they never expire, and removing the song removes them. There is no separate cache to keep in sync.

### Changes

- `common_services.dart`:
  - `cacheSponsorBlockSegments()` — looks a song up once and stores the result during `makeSongOffline()`. A confirmed empty result is stored too, so a song known to have no segments is never looked up again.
  - `getCachedSponsorBlockSegments()` — synchronous, offline-safe read. `null` means nothing stored yet; `[]` means looked up and confirmed to have none.
  - `_fetchSkipSegments()` — the request itself, split out of `getSkipSegments()`. It throws on failure instead of swallowing it, which is what lets the offline cache tell "confirmed no segments" apart from "failed to fetch". `getSkipSegments()` keeps its previous behaviour (returns `[]` on any error) for the online path.
  - `_sponsorSerialCall()` — serializes all SponsorBlock API calls through a single `Future` chain, so one request is in flight at a time, spaced 1s apart.
- `audio_service.dart`:
  - `_buildSkippedAudioSource()` — the clipping logic, extracted so the online and offline paths share it instead of duplicating it.
  - `_applyOfflineSponsorBlock()` — applies stored segments to an offline audio source, and kicks off a background lookup when a song has nothing stored yet.

### Not storing false negatives

The distinction between "this video genuinely has no segments" and "the lookup failed" matters, because a stored empty result is permanent — it is never looked up again. So:

- **404 / `Not Found`** is how the API answers "no segments for this video". That is a real empty result and gets stored.
- **Any other non-200, a network error, or a parse error** throws. `cacheSponsorBlockSegments()` then retries once (spaced by the queue below), and if that fails too it stores nothing, so the song is simply looked up again the next time it plays.

### Rate limiting

SponsorBlock's public API (`sponsor.ajay.app`) documents no official rate limit, but it is a shared unauthenticated third-party endpoint, so this is conservative about how often it is hit:

- **One lookup per song, ever** — including songs confirmed to have no segments.
- **Serialized requests** — every lookup goes through a single `Future` chain (`_sponsorSerialCall`) that guarantees one request in flight at a time, 1s apart. This matters because `cacheSponsorBlockSegments()` is called with `unawaited(...)` from `makeSongOffline()`, so it does not block the download queue — several songs can finish downloading close together (a large playlist download runs 3 concurrent workers) and each fires its own lookup independently. An earlier revision used a timestamp throttle instead of a real queue, which had a race: concurrent calls could all read the same "last call" timestamp before any of them updated it and end up firing together. The `Future`-chain approach fixes that by construction, since Dart's event loop guarantees no interleaving between reading and reassigning the chain.

This makes the feature safe on very large playlists (500+ songs) without a burst of simultaneous requests to a third-party API.
