### PR TITLE
fix: include user playlists in offline auto-detection (#891 complement)

### DIFF
--- a/lib/services/playlist_download_service.dart
+++ b/lib/services/playlist_download_service.dart
@@ -180,7 +180,17 @@ class OfflinePlaylistService {
         final offlineSongIds = userOfflineSongs.value
             .map((s) => s['ytid'])
             .toSet();
-        for (final p in playlists) {
+
+        final seenIds = <String>{};
+        final userPlaylistSources = <Map>[
+          ...userCustomPlaylists.value,
+          ...userLikedPlaylists.value,
+          ...playlists,
+        ].where((p) {
+          final id = p['ytid']?.toString();
+          return id != null && seenIds.add(id);
+        }).toList();
+        for (final p in userPlaylistSources) {
           final pList = p['list'] as List?;
           if (pList == null ||
               pList.isEmpty ||

--- a/lib/services/playlist_download_service.dart
+++ b/lib/services/playlist_download_service.dart
@@ -70,6 +70,43 @@ class OfflinePlaylistService {
     return activeDownloads.contains(playlistId);
   }
 
+  /// Checks whether [playlist] now has 100% of its songs downloaded offline
+  /// and, if so, marks it offline too.
+  ///
+  /// Unlike the batch scan in [_handleDownloadCompletion] (which only runs
+  /// right after a playlist finishes downloading), this is meant to be
+  /// called any time a single playlist's song list or like-status changes —
+  /// e.g. after adding a song to a custom playlist, or liking a playlist —
+  /// so playlists created/modified *after* the triggering download aren't
+  /// silently skipped.
+  void checkAndAutoMarkOffline(Map playlist) {
+    final id = playlist['ytid']?.toString();
+    final pList = playlist['list'] as List?;
+    if (id == null || pList == null || pList.isEmpty) return;
+    if (isPlaylistDownloaded(id)) return;
+
+    final offlineSongIds = userOfflineSongs.value
+        .map((s) => s['ytid'])
+        .toSet();
+    if (!pList.every((s) => offlineSongIds.contains(s['ytid']))) return;
+
+    offlinePlaylists.value = [
+      ...offlinePlaylists.value,
+      {
+        ...playlist,
+        'list': pList,
+        'downloadedAt': DateTime.now().millisecondsSinceEpoch,
+      },
+    ];
+    unawaited(
+      addOrUpdateData<List>(
+        'userNoBackup',
+        'offlinePlaylists',
+        offlinePlaylists.value,
+      ),
+    );
+  }
+
   Future<void> downloadPlaylist(BuildContext context, Map playlist) async {
     final playlistId = playlist['ytid'] as String? ?? playlist['title'];
 

--- a/lib/services/playlist_download_service.dart
+++ b/lib/services/playlist_download_service.dart
@@ -185,6 +185,8 @@ class OfflinePlaylistService {
         final userPlaylistSources = <Map>[
           ...userCustomPlaylists.value,
           ...userLikedPlaylists.value,
+          for (final folder in userPlaylistFolders.value)
+            ...List<Map>.from(folder['playlists'] ?? []),
           ...playlists,
         ].where((p) {
           final id = p['ytid']?.toString();

--- a/lib/services/playlists_manager.dart
+++ b/lib/services/playlists_manager.dart
@@ -276,6 +276,7 @@ String addSongInCustomPlaylist(
       );
     }
 
+    offlinePlaylistService.checkAndAutoMarkOffline(customPlaylist);
     return context.l10n!.songAdded;
   } else {
     logger.log('Custom playlist not found for ytid: $playlistId');
@@ -336,6 +337,7 @@ String addSongsInCustomPlaylist(
           ),
         );
       }
+      offlinePlaylistService.checkAndAutoMarkOffline(customPlaylist);
       return context.l10n!.addedSuccess;
     } else {
       return context.l10n!.songAlreadyInPlaylist;
@@ -1323,6 +1325,7 @@ Future<void> updatePlaylistLikeStatus(
             (playlist) => playlist['ytid']?.toString() == normalizedPlaylistId,
           )) {
         updatedLikedPlaylists.add(playlistToAdd);
+        offlinePlaylistService.checkAndAutoMarkOffline(playlistToAdd);
       }
     } else {
       updatedLikedPlaylists.removeWhere(


### PR DESCRIPTION
This complements PR #891 by extending the offline auto-detection to also scan **user-created** (`userCustomPlaylists`) and **liked** (`userLikedPlaylists`) playlists — not just the editorial/session cache.

Previously the loop only iterated over `playlists` (editorial `playlistsDB` + `albumsDB` + session cache), so user-created or liked playlists were never auto-marked offline when all their songs were downloaded via another playlist. The combined source list is also deduplicated by `ytid` to prevent duplicate offline entries.

Closes the gap where playlists the user actually interacts with were silently ignored by the feature introduced in #891.