### PR TITLE
Feat/sleep timer fadeout

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -74,6 +74,11 @@ class MusifyAudioHandler extends BaseAudioHandler {
   Timer? _debounceTimer;
   bool sleepTimerExpired = false;
   bool sleepTimerEndOfSong = false;
+  bool _sleepTimerFading = false;
+  double _preFadeVolume = 1;
+
+  static const int _sleepTimerFadeSteps = 20;
+  static const Duration _sleepTimerFadeDuration = Duration(seconds: 6);
 
   final List<Map> _queueList = [];
   final List<Map> _originalQueueList = [];
@@ -2449,21 +2454,90 @@ class MusifyAudioHandler extends BaseAudioHandler {
   Future<void> setSleepTimer(Duration duration) async {
     try {
       _sleepTimer?.cancel();
+      if (_sleepTimerFading) {
+        // A fade from a previous timer is still running; restore volume
+        // immediately instead of waiting for its next step to notice.
+        _sleepTimerFading = false;
+        await audioPlayer.setVolume(_preFadeVolume);
+      }
       sleepTimerExpired = false;
       sleepTimerNotifier.value = duration;
 
-      _sleepTimer = Timer(duration, () async {
+      // Start the fade so total playback duration lands on the exact target.
+      // A duration shorter than the fade itself fades out right away rather
+      // than scheduling a timer in the past.
+      final fadeStart = duration > _sleepTimerFadeDuration
+          ? duration - _sleepTimerFadeDuration
+          : Duration.zero;
+      _sleepTimer = Timer(fadeStart, () async {
         sleepTimerExpired = true;
-        await stop();
-        sleepTimerNotifier.value = null;
+        await _performSleepTimerFadeOut();
       });
     } catch (e, stackTrace) {
       logger.log('Error setting sleep timer', error: e, stackTrace: stackTrace);
     }
   }
 
-  void cancelSleepTimer() {
+  Future<void> _performSleepTimerFadeOut() async {
+    _sleepTimerFading = true;
+    _preFadeVolume = audioPlayer.volume;
+    final start = DateTime.now();
+    // Set when this fade is cancelled or replaced by a newer timer while it
+    // was sleeping between steps, so it knows the timer state is no longer
+    // its to clear.
+    var superseded = false;
+
     try {
+      for (var i = 1; i <= _sleepTimerFadeSteps; i++) {
+        // Anchor each step to elapsed wall-clock time instead of summing fixed
+        // delays, so the setVolume platform-channel call overhead doesn't
+        // accumulate into extra seconds by the end of the fade.
+        final targetElapsed =
+            _sleepTimerFadeDuration * i ~/ _sleepTimerFadeSteps;
+        final remaining = targetElapsed - DateTime.now().difference(start);
+        if (remaining > Duration.zero) {
+          await Future.delayed(remaining);
+        }
+        if (!_sleepTimerFading) {
+          superseded = true;
+          await audioPlayer.setVolume(_preFadeVolume);
+          return;
+        }
+        await audioPlayer.setVolume(
+          _preFadeVolume * (1 - (i / _sleepTimerFadeSteps)),
+        );
+      }
+
+      _sleepTimerFading = false;
+      await stop();
+      // Restore volume only after stop to avoid audible click
+      await audioPlayer.setVolume(_preFadeVolume);
+    } catch (e, stackTrace) {
+      _sleepTimerFading = false;
+      logger.log(
+        'Error during sleep timer fade out',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      // Never leave playback muted because the fade broke partway through.
+      try {
+        await audioPlayer.setVolume(_preFadeVolume);
+      } catch (_) {}
+    } finally {
+      // Only a fade that ran to the end owns the timer state. One that was
+      // cancelled or replaced must not clear the timer that replaced it.
+      if (!superseded) sleepTimerNotifier.value = null;
+    }
+  }
+
+  Future<void> cancelSleepTimer() async {
+    try {
+      if (_sleepTimerFading) {
+        // Stop an in-progress fade and put the volume back right away instead
+        // of waiting for its next step to notice.
+        _sleepTimerFading = false;
+        await audioPlayer.setVolume(_preFadeVolume);
+      }
       _sleepTimer?.cancel();
       _sleepTimer = null;
       sleepTimerExpired = false;
@@ -2481,6 +2555,12 @@ class MusifyAudioHandler extends BaseAudioHandler {
   Future<void> setSleepTimerEndOfSong() async {
     try {
       _sleepTimer?.cancel();
+      if (_sleepTimerFading) {
+        // Otherwise the fade left over from the previous timer would keep
+        // going and stop playback before the song ends.
+        _sleepTimerFading = false;
+        await audioPlayer.setVolume(_preFadeVolume);
+      }
       sleepTimerExpired = false;
       sleepTimerEndOfSong = true;
       sleepTimerNotifier.value = const Duration(milliseconds: -1);

--- a/lib/widgets/now_playing/bottom_actions_row.dart
+++ b/lib/widgets/now_playing/bottom_actions_row.dart
@@ -284,9 +284,9 @@ class _BottomActionsRowState extends State<BottomActionsRow> {
               borderRadius: BorderRadius.circular(12),
             ),
           ),
-          onPressed: () {
+          onPressed: () async {
             if (isActive) {
-              audioHandler.cancelSleepTimer();
+              await audioHandler.cancelSleepTimer();
               sleepTimerNotifier.value = null;
               showToast(
                 context,


### PR DESCRIPTION
Sleep timer now fades playback out instead of stopping abruptly.

### Changes

- `setSleepTimer()`: the timer fires 6 seconds before the target duration, then hands off to a fade instead of calling `stop()` directly — so the total time-to-silence still matches what the user set.
- `_performSleepTimerFadeOut()`: linearly ramps volume down to 0 over 6 seconds (20 steps), then stops playback and restores volume. The fade is anchored to elapsed wall-clock time rather than summing fixed per-step delays, so the platform-channel overhead of each `setVolume` call doesn't accumulate into extra seconds by the end of the fade.
- Captures the volume in place before the fade starts and restores that value afterward, instead of assuming full volume.

### Behavior around interruptions

The timer (and its fade) are intentionally decoupled from playback controls — pausing, skipping, adding to the queue, or changing repeat mode never cancels it. This matches the app's existing pre-fade sleep timer behavior, and how Spotify's own sleep timer works: it keeps counting down and stops on schedule no matter what's currently playing.

The three actions that *do* take over a running fade all stop it and restore the volume immediately, rather than waiting for its next step to notice:

- **Cancelling** the sleep timer — clears everything, as before.
- **Setting a new timer** during the fade window — the new timer takes over. A fade that has been replaced no longer clears the timer state on its way out, which would otherwise leave the button reading as inactive while playback was still scheduled to stop.
- **Switching to end-of-song** during the fade window — the fade stops instead of continuing to ramp down and calling `stop()` before the song actually ends.

If the fade itself throws partway through, the volume is put back, so a failed fade can't leave playback muted with nothing in the UI able to undo it.

Tested on-device over wireless debugging: timer fires, fade is audible and click-free, and skipping/pausing/queueing during the fade window no longer cancels the timer.
