### PR TITLE
Add optional audio quality badge on now playing artwork

### DIFF
--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -18,6 +18,8 @@
   "artist": "Artist",
   "artists": "Artists",
   "audioQuality": "Audio quality",
+  "audioQualityBadge": "Show audio quality badge",
+  "audioQualityBadgeDescription": "Display a small bitrate/codec badge on the now playing artwork.",
   "audioQualityHigh": "High",
   "audioQualityLow": "Low",
   "audioQualityMedium": "Medium",

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -113,6 +113,20 @@ class SettingsPage extends StatelessWidget {
           FluentIcons.music_note_1_24_regular,
           onTap: () => _showAudioQualityPicker(context),
         ),
+        ValueListenableBuilder<bool>(
+          valueListenable: showAudioQualityBadge,
+          builder: (_, value, __) {
+            return CustomBar(
+              context.l10n!.audioQualityBadge,
+              FluentIcons.badge_24_regular,
+              description: context.l10n!.audioQualityBadgeDescription,
+              trailing: Switch(
+                value: value,
+                onChanged: (value) => _toggleAudioQualityBadge(context, value),
+              ),
+            );
+          },
+        ),
         CustomBar(
           context.l10n!.equalizer,
           FluentIcons.data_histogram_24_regular,
@@ -745,6 +759,12 @@ class SettingsPage extends StatelessWidget {
         ? const PredictiveBackPageTransitionsBuilder()
         : const CupertinoPageTransitionsBuilder();
     Musify.updateAppState(context);
+    showToast(context, context.l10n!.settingChangedMsg);
+  }
+
+  void _toggleAudioQualityBadge(BuildContext context, bool value) {
+    addOrUpdateData<bool>('settings', 'showAudioQualityBadge', value);
+    showAudioQualityBadge.value = value;
     showToast(context, context.l10n!.settingChangedMsg);
   }
 

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -2072,8 +2072,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
         }
         final songId = song['ytid']?.toString();
         if (songId != null && songId.isNotEmpty) {
-          final cacheKey = 'song_${songId}_${audioQualitySetting.value}_url';
-          await deleteData('cache', cacheKey);
+          await invalidateSongStreamCache(songId);
 
           final refreshedUrl = await fetchSongStreamUrl(
             songId,

--- a/lib/services/common_services.dart
+++ b/lib/services/common_services.dart
@@ -547,6 +547,51 @@ Future<void> getSimilarSong(String songYtId) async {
   }
 }
 
+/// In-memory cache of the audio stream picked for a song at the current
+/// quality setting. The Hive cache only keeps the URL, so without this every
+/// caller that needs the stream itself (bitrate, codec) would fetch the
+/// manifest again right after playback already resolved it.
+final Map<String, ({AudioOnlyStreamInfo stream, DateTime resolvedAt})>
+_selectedAudioStreams = {};
+
+const _maxSelectedAudioStreams = 50;
+
+String _selectedAudioStreamKey(String songId) =>
+    '${songId}_${audioQualitySetting.value}';
+
+/// Returns the stream resolved earlier for a song, unless it is old enough
+/// that its URL may have expired.
+AudioOnlyStreamInfo? _getSelectedAudioStream(String songId) {
+  final key = _selectedAudioStreamKey(songId);
+  final entry = _selectedAudioStreams[key];
+  if (entry == null) return null;
+
+  if (DateTime.now().difference(entry.resolvedAt) > _cacheValidationDuration) {
+    _selectedAudioStreams.remove(key);
+    return null;
+  }
+
+  return entry.stream;
+}
+
+void _cacheSelectedAudioStream(String songId, AudioOnlyStreamInfo stream) {
+  if (_selectedAudioStreams.length >= _maxSelectedAudioStreams) {
+    _selectedAudioStreams.remove(_selectedAudioStreams.keys.first);
+  }
+
+  _selectedAudioStreams[_selectedAudioStreamKey(songId)] = (
+    stream: stream,
+    resolvedAt: DateTime.now(),
+  );
+}
+
+/// Drops both cached forms of a song's stream, so the next request resolves
+/// it again. Used when a cached URL turns out to be dead.
+Future<void> invalidateSongStreamCache(String songId) async {
+  _selectedAudioStreams.remove(_selectedAudioStreamKey(songId));
+  await deleteData('cache', 'song_${songId}_${audioQualitySetting.value}_url');
+}
+
 /// Fetches the best available audio stream for a song.
 Future<AudioOnlyStreamInfo?> fetchBestAudioStream(String? songId) async {
   try {
@@ -555,13 +600,21 @@ Future<AudioOnlyStreamInfo?> fetchBestAudioStream(String? songId) async {
       return null;
     }
 
+    final cachedStream = _getSelectedAudioStream(songId);
+    if (cachedStream != null) return cachedStream;
+
     final manifest = await _fetchStreamManifest(songId);
     final audioStream = manifest?.audioOnly;
     if (audioStream == null || audioStream.isEmpty) {
       logger.log('fetchBestAudioStream: no audio streams for $songId');
       return null;
     }
-    return selectAudioOnlyStreamForQuality(audioStream.sortByBitrate());
+
+    final selectedStream = selectAudioOnlyStreamForQuality(
+      audioStream.sortByBitrate(),
+    );
+    _cacheSelectedAudioStream(songId, selectedStream);
+    return selectedStream;
   } on TimeoutException catch (_) {
     logger.log('fetchBestAudioStream request timed out for $songId');
     return null;
@@ -597,17 +650,13 @@ Future<String?> fetchSongStreamUrl(String songId, bool isLive) async {
       return cachedUrl;
     }
 
-    // Get fresh URL
-    final manifest = await _fetchStreamManifest(songId);
-    final audioStreams = manifest?.audioOnly;
-    if (audioStreams == null || audioStreams.isEmpty) {
+    // Get fresh URL, reusing the stream already resolved for this song.
+    final selectedStream = await fetchBestAudioStream(songId);
+    if (selectedStream == null) {
       logger.log('fetchSongStreamUrl: no audio streams for $songId');
       return null;
     }
 
-    final selectedStream = selectAudioOnlyStreamForQuality(
-      audioStreams.sortByBitrate(),
-    );
     final url = selectedStream.url.toString();
 
     unawaited(addOrUpdateData<String>('cache', cacheKey, url));
@@ -687,6 +736,8 @@ Future<bool> makeSongOffline(dynamic song) async {
 
     await audioFile.parent.create(recursive: true);
 
+    int? audioBitrateKbps;
+    String? audioCodec;
     IOSink? fileStream;
     try {
       final audioManifest = await fetchBestAudioStream(ytid);
@@ -694,6 +745,8 @@ Future<bool> makeSongOffline(dynamic song) async {
         logger.log('makeSongOffline: audioManifest is null for $ytid');
         return false;
       }
+      audioBitrateKbps = audioManifest.bitrate.kiloBitsPerSecond.round();
+      audioCodec = audioManifest.audioCodec;
 
       final stream = ytClient.videos.streamsClient.get(audioManifest);
       fileStream = audioFile.openWrite();
@@ -739,6 +792,8 @@ Future<bool> makeSongOffline(dynamic song) async {
     }
 
     offlineSong['audioPath'] = audioFile.path;
+    offlineSong['audioBitrateKbps'] = audioBitrateKbps;
+    offlineSong['audioCodec'] = audioCodec;
     offlineSong['dateAdded'] = DateTime.now().millisecondsSinceEpoch;
 
     try {

--- a/lib/services/settings_manager.dart
+++ b/lib/services/settings_manager.dart
@@ -72,6 +72,10 @@ final audioQualitySetting = ValueNotifier<String>(
   Hive.box('settings').get('audioQuality', defaultValue: 'high'),
 );
 
+final showAudioQualityBadge = ValueNotifier<bool>(
+  Hive.box('settings').get('showAudioQualityBadge', defaultValue: false),
+);
+
 List<double> _readEqualizerGains() {
   final raw = Hive.box(
     'settings',

--- a/lib/widgets/now_playing/now_playing_artwork.dart
+++ b/lib/widgets/now_playing/now_playing_artwork.dart
@@ -19,6 +19,8 @@
  *     please visit: https://github.com/gokadzev/Musify
  */
 
+import 'dart:async';
+
 import 'package:audio_service/audio_service.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
@@ -75,14 +77,23 @@ class NowPlayingArtwork extends StatelessWidget {
             ),
           ],
         ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(borderRadius),
-          child: SongArtworkWidget(
-            metadata: metadata,
-            size: imageSize,
-            errorWidgetIconSize: size.width / 8,
-            borderRadius: borderRadius,
-          ),
+        child: Stack(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(borderRadius),
+              child: SongArtworkWidget(
+                metadata: metadata,
+                size: imageSize,
+                errorWidgetIconSize: size.width / 8,
+                borderRadius: borderRadius,
+              ),
+            ),
+            Positioned(
+              right: 10,
+              bottom: 10,
+              child: _AudioQualityBadge(metadata: metadata),
+            ),
+          ],
         ),
       ),
       backWidget: Container(
@@ -166,6 +177,109 @@ class NowPlayingArtwork extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+typedef _AudioQualityInfo = ({int bitrateKbps, String codec});
+
+String _normalizeCodec(String codec) => switch (codec) {
+  final c when c.startsWith('opus') => 'Opus',
+  final c when c.startsWith('mp4a') => 'AAC',
+  final c => c,
+};
+
+/// Resolves once per song: reads the quality stored at download time for a
+/// downloaded song (no network, works offline), otherwise reads the stream
+/// resolved for playback. Returns null if there's nothing to show.
+Future<_AudioQualityInfo?> _resolveAudioQuality(String ytid) async {
+  final offlineSong = getOfflineSongByYtid(ytid);
+  final offlineBitrate = offlineSong['audioBitrateKbps'] as int?;
+  final offlineCodec = offlineSong['audioCodec'] as String?;
+  if (offlineBitrate != null && offlineCodec != null) {
+    return (bitrateKbps: offlineBitrate, codec: _normalizeCodec(offlineCodec));
+  }
+  if (offlineSong.isNotEmpty || offlineMode.value) return null;
+
+  // Free for a song that is playing: the stream it picked is already resolved
+  // and cached, so this reads it back instead of asking YouTube again.
+  final stream = await fetchBestAudioStream(ytid);
+  if (stream == null) return null;
+
+  return (
+    bitrateKbps: stream.bitrate.kiloBitsPerSecond.round(),
+    codec: _normalizeCodec(stream.audioCodec),
+  );
+}
+
+/// Shows the current song's audio bitrate/codec once it's resolved.
+///
+/// Resolves the info a single time per song (whenever [metadata]'s ytid
+/// changes) instead of watching anything, since the badge is a one-shot,
+/// purely cosmetic overlay. Reopening the screen resolves again, which is what
+/// makes it pick up a change of the setting without listening to it — the
+/// stream is cached per quality setting, so that costs nothing.
+class _AudioQualityBadge extends StatefulWidget {
+  const _AudioQualityBadge({required this.metadata});
+  final MediaItem metadata;
+
+  @override
+  State<_AudioQualityBadge> createState() => _AudioQualityBadgeState();
+}
+
+class _AudioQualityBadgeState extends State<_AudioQualityBadge> {
+  String? _resolvedYtid;
+  Future<_AudioQualityInfo?>? _infoFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveIfNeeded();
+  }
+
+  @override
+  void didUpdateWidget(_AudioQualityBadge oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _resolveIfNeeded();
+  }
+
+  void _resolveIfNeeded() {
+    final ytid = widget.metadata.extras?['ytid']?.toString();
+    if (ytid == _resolvedYtid) return;
+    _resolvedYtid = ytid;
+
+    final shouldResolve =
+        showAudioQualityBadge.value && ytid != null && ytid.isNotEmpty;
+    _infoFuture = shouldResolve ? _resolveAudioQuality(ytid) : null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final infoFuture = _infoFuture;
+    if (infoFuture == null) return const SizedBox.shrink();
+
+    return FutureBuilder<_AudioQualityInfo?>(
+      future: infoFuture,
+      builder: (context, snapshot) {
+        final info = snapshot.data;
+        if (info == null) return const SizedBox.shrink();
+
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.55),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Text(
+            '${info.bitrateKbps} kbps • ${info.codec}',
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Adds an off-by-default badge on the now playing artwork showing the current song's bitrate/codec (e.g. `128 kbps • AAC`), toggled right next to the audio quality picker in Settings.
- **Works both online and offline.** For a downloaded song, the badge reads the bitrate/codec captured once at download time (stored alongside `audioPath` in the offline song record) — zero network calls, works with no connection. For a song streaming online, it reuses the stream already resolved for playback, skipped entirely when the global Offline mode setting is on.
- **Costs no extra request.** Following review feedback, the audio stream selected for a song is now kept in an in-memory map in `common_services`, keyed by song id and audio quality setting, rather than only its URL reaching the Hive cache. `fetchSongStreamUrl` goes through `fetchBestAudioStream`, so the stream manifest is fetched once per song no matter how many callers need it, and the badge adds nothing on top once playback has resolved the song. Entries expire on the same window the URL cache already treated as fresh, and the map is capped so it can't grow unbounded over a long session.
- Kept minimal otherwise: no listener on playback state, and the only touch to the playback path is the retry branch now dropping both caches together (`invalidateSongStreamCache`) instead of just the URL key — without that a retry would reuse the stale stream and hit the same dead URL.

## Known limitation
Songs downloaded **before** this change won't have `audioBitrateKbps`/`audioCodec` stored in their offline record, so the badge won't show for them until they're re-downloaded. Intentionally not adding a backfill/migration step for this — fetching quality info in bulk for the whole existing download library felt like unnecessary weight for a purely cosmetic badge. It self-resolves naturally as songs get re-downloaded.

Closes #828
