### PR TITLE
fix(artist): keep refreshed catalogs in sync with offline downloads

### DIFF
--- a/lib/constants/artist_constants.dart
+++ b/lib/constants/artist_constants.dart
@@ -20,9 +20,9 @@
  */
 
 /// Cache versioning constants for artist-related data
-const int artistCatalogCacheVersion = 15;
+const int artistCatalogCacheVersion = 16;
 const int artistSearchCacheVersion = 10;
-const int artistProfileCacheVersion = 4;
+const int artistProfileCacheVersion = 5;
 const int artistAlbumCacheVersion = 2;
 const int artistChannelCacheVersion = 2;
 

--- a/lib/screens/artist_page.dart
+++ b/lib/screens/artist_page.dart
@@ -170,7 +170,7 @@ class _ArtistPageState extends State<ArtistPage> {
           generation != _artistLoadGeneration) {
         return null;
       }
-      await cacheArtistProfile(artist);
+      cacheArtistProfileInBackground(artist);
     }
 
     _artist = artist;
@@ -182,9 +182,9 @@ class _ArtistPageState extends State<ArtistPage> {
     _cachedResolvedArtistId = null;
     _cachedArtistTitle = null;
     // Each entry of the shelf is a song and its play count, side by side.
-    final topSongs = asMapList(
-      artist['topSongs'],
-    ).where((entry) => entry['song'] is Map).toList();
+    final topSongs = asMapList(artist['topSongs'])
+        .where((entry) => entry['song'] is Map)
+        .toList();
     _topSongs = [
       for (final entry in topSongs)
         Map<String, dynamic>.from(entry['song'] as Map),
@@ -412,17 +412,20 @@ class _ArtistPageState extends State<ArtistPage> {
     _catalogFuture = future;
     final catalog = await future;
 
+    final ownsFuture = identical(_catalogFuture, future);
     final isCurrent =
         mounted &&
         generation == _artistLoadGeneration &&
         artistId == _resolvedArtistId &&
-        identical(_catalogFuture, future);
-    if (catalog != null && catalog['catalogStatus'] != 'failed' && isCurrent) {
+        ownsFuture;
+    if (ownsFuture) _catalogFuture = null;
+    if (!isCurrent) return null;
+
+    if (catalog != null && catalog['catalogStatus'] != 'failed') {
       setState(() {
         _catalog = Map<String, dynamic>.from(catalog);
       });
     }
-    if (identical(_catalogFuture, future)) _catalogFuture = null;
     return catalog;
   }
 

--- a/lib/screens/artist_page.dart
+++ b/lib/screens/artist_page.dart
@@ -38,6 +38,7 @@ import 'package:musify/utilities/flutter_toast.dart';
 import 'package:musify/widgets/artist_shelf.dart';
 import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/playlist_cube.dart';
+import 'package:musify/widgets/playlist_page/add_to_playlist_button.dart';
 import 'package:musify/widgets/playlist_page/download_button.dart';
 import 'package:musify/widgets/playlist_page/empty_playlist_state.dart';
 import 'package:musify/widgets/playlist_page/like_button.dart';
@@ -65,6 +66,8 @@ class _ArtistPageState extends State<ArtistPage> {
   Future<Map<String, dynamic>?>? _artistFuture;
 
   Map<String, dynamic>? _artist;
+  Map<String, dynamic>? _catalog;
+  Future<Map?>? _catalogFuture;
   List<Map<String, dynamic>> _topSongs = const [];
   List<String?> _topSongPlayCounts = const [];
   List<Map<String, dynamic>> _albums = const [];
@@ -86,13 +89,18 @@ class _ArtistPageState extends State<ArtistPage> {
   Future<void> _refresh() async {
     final generation = ++_artistLoadGeneration;
     final loaded = _artistFuture;
-    final refreshed = _loadArtist(forceRefresh: true);
+    final refreshed = _loadArtist(forceRefresh: true, refreshCatalog: true);
     // Block syntax: setState doesn't accept Future-returning callbacks
     setState(() {
       _artistFuture = refreshed;
     });
 
-    final refreshedArtist = await refreshed;
+    Map<String, dynamic>? refreshedArtist;
+    try {
+      refreshedArtist = await refreshed;
+    } catch (_) {
+      refreshedArtist = null;
+    }
     if (!mounted ||
         generation != _artistLoadGeneration ||
         refreshedArtist != null) {
@@ -111,6 +119,8 @@ class _ArtistPageState extends State<ArtistPage> {
     if (oldWidget.artistId != widget.artistId) {
       _artistLoadGeneration++;
       _artistFuture = null;
+      _catalog = null;
+      _catalogFuture = null;
       _cachedResolvedArtistId = null;
       _cachedArtistTitle = null;
     }
@@ -130,12 +140,16 @@ class _ArtistPageState extends State<ArtistPage> {
       widget.artistData?['title']?.toString() ??
       '';
 
-  Future<Map<String, dynamic>?> _loadArtist({bool forceRefresh = false}) async {
+  Future<Map<String, dynamic>?> _loadArtist({
+    bool forceRefresh = false,
+    bool refreshCatalog = false,
+  }) async {
     final generation = _artistLoadGeneration;
     final artistData = widget.artistData;
     final artist = await getArtistProfile(
       widget.artistId,
       forceRefresh: forceRefresh,
+      cacheResult: !refreshCatalog,
       preferredName: artistData?['title']?.toString(),
       preferredImage: artistData?['image']?.toString(),
       sourceSongId: artistData?['sourceSongId']?.toString(),
@@ -146,14 +160,30 @@ class _ArtistPageState extends State<ArtistPage> {
       return null;
     }
 
+    Map<String, dynamic>? catalog;
+    if (refreshCatalog) {
+      catalog = await getArtistCatalogFromProfile(artist, forceRebuild: true);
+      if (catalog == null ||
+          catalog['catalogStatus'] == 'failed' ||
+          !mounted ||
+          generation != _artistLoadGeneration) {
+        return null;
+      }
+      await cacheArtistProfile(artist);
+    }
+
     _artist = artist;
+    if (refreshCatalog) {
+      _catalog = catalog;
+      _catalogFuture = null;
+    }
     // Clear caches when artist data updates
     _cachedResolvedArtistId = null;
     _cachedArtistTitle = null;
     // Each entry of the shelf is a song and its play count, side by side.
-    final topSongs = asMapList(artist['topSongs'])
-        .where((entry) => entry['song'] is Map)
-        .toList();
+    final topSongs = asMapList(
+      artist['topSongs'],
+    ).where((entry) => entry['song'] is Map).toList();
     _topSongs = [
       for (final entry in topSongs)
         Map<String, dynamic>.from(entry['song'] as Map),
@@ -290,10 +320,13 @@ class _ArtistPageState extends State<ArtistPage> {
               playlistId: _resolvedArtistId,
               playlistData: () => artistPlaylistData(_artist!, songs: const []),
             ),
+            PlaylistAddToPlaylistButton(resolvePlaylist: _loadCatalog),
             // Downloading artist = downloading all its songs
             PlaylistDownloadButton(
               playlistId: _resolvedArtistId,
               resolvePlaylist: _loadCatalog,
+              songs: _catalog?['list'] as List?,
+              requireSnapshotMatch: true,
             ),
             IconButton.filledTonal(
               icon: const Icon(FluentIcons.arrow_sync_24_filled),
@@ -363,14 +396,40 @@ class _ArtistPageState extends State<ArtistPage> {
     return year == null || year.isEmpty ? type : '$type • $year';
   }
 
-  // Shares catalog with "All songs" page (read once, reused everywhere)
-  Future<Map?> _loadCatalog() => getPlaylistInfoForWidget(
-    _resolvedArtistId,
-    isArtist: true,
-    artistName: _artistTitle,
-    artistImage: _artist?['image']?.toString(),
-    preferredVerified: _artist?['isVerifiedArtist'] == true,
-  );
+  // Shares the complete catalog with "All songs" and keeps it after the first
+  // action so play, add and download cannot resolve different song snapshots.
+  Future<Map?> _loadCatalog() async {
+    final loadedCatalog = _catalog;
+    if (loadedCatalog != null) return loadedCatalog;
+
+    final inFlight = _catalogFuture;
+    if (inFlight != null) return inFlight;
+
+    final future = _resolveCatalog();
+    _catalogFuture = future;
+    final catalog = await future;
+
+    if (catalog != null && catalog['catalogStatus'] != 'failed' && mounted) {
+      setState(() {
+        _catalog = Map<String, dynamic>.from(catalog);
+      });
+    }
+    if (identical(_catalogFuture, future)) _catalogFuture = null;
+    return catalog;
+  }
+
+  Future<Map?> _resolveCatalog() {
+    final artist = _artist;
+    if (artist != null) return getArtistCatalogFromProfile(artist);
+
+    return getPlaylistInfoForWidget(
+      _resolvedArtistId,
+      isArtist: true,
+      artistName: _artistTitle,
+      artistImage: _artist?['image']?.toString(),
+      preferredVerified: _artist?['isVerifiedArtist'] == true,
+    );
+  }
 
   Future<void> _playArtist({bool shuffle = false}) async {
     _isLoadingCatalog.value = true;

--- a/lib/screens/artist_page.dart
+++ b/lib/screens/artist_page.dart
@@ -89,6 +89,7 @@ class _ArtistPageState extends State<ArtistPage> {
   Future<void> _refresh() async {
     final generation = ++_artistLoadGeneration;
     final loaded = _artistFuture;
+    _catalogFuture = null;
     final refreshed = _loadArtist(forceRefresh: true, refreshCatalog: true);
     // Block syntax: setState doesn't accept Future-returning callbacks
     setState(() {
@@ -405,11 +406,18 @@ class _ArtistPageState extends State<ArtistPage> {
     final inFlight = _catalogFuture;
     if (inFlight != null) return inFlight;
 
+    final generation = _artistLoadGeneration;
+    final artistId = _resolvedArtistId;
     final future = _resolveCatalog();
     _catalogFuture = future;
     final catalog = await future;
 
-    if (catalog != null && catalog['catalogStatus'] != 'failed' && mounted) {
+    final isCurrent =
+        mounted &&
+        generation == _artistLoadGeneration &&
+        artistId == _resolvedArtistId &&
+        identical(_catalogFuture, future);
+    if (catalog != null && catalog['catalogStatus'] != 'failed' && isCurrent) {
       setState(() {
         _catalog = Map<String, dynamic>.from(catalog);
       });

--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -35,13 +35,13 @@ import 'package:musify/services/playlists_manager.dart';
 import 'package:musify/services/settings_manager.dart';
 import 'package:musify/utilities/app_utils.dart';
 import 'package:musify/utilities/flutter_toast.dart';
-import 'package:musify/utilities/playlist_dialogs.dart';
 import 'package:musify/utilities/playlist_utils.dart';
 import 'package:musify/utilities/song_filtering.dart';
 import 'package:musify/utilities/sort_utils.dart';
 import 'package:musify/widgets/edit_playlist_dialog.dart';
 import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/playlist_cube.dart';
+import 'package:musify/widgets/playlist_page/add_to_playlist_button.dart';
 import 'package:musify/widgets/playlist_page/download_button.dart';
 import 'package:musify/widgets/playlist_page/empty_playlist_state.dart';
 import 'package:musify/widgets/playlist_page/like_button.dart';
@@ -304,7 +304,9 @@ class _PlaylistPageState extends State<PlaylistPage> {
                   playlistData: () => _playlist,
                 ),
               if (!offlineMode.value) ...[
-                _buildAddToPlaylistButton(),
+                PlaylistAddToPlaylistButton(
+                  resolvePlaylist: () async => _playlist,
+                ),
                 if (!isUserCreated) _buildSyncButton(),
               ],
               if (songsLength > 0) _buildDownloadButton(),
@@ -382,28 +384,6 @@ class _PlaylistPageState extends State<PlaylistPage> {
       onPressed: _handleSyncPlaylist,
       tooltip: context.l10n!.update,
     );
-  }
-
-  Widget _buildAddToPlaylistButton() {
-    return IconButton.filledTonal(
-      icon: const Icon(FluentIcons.album_add_24_regular),
-      iconSize: 24,
-      onPressed: _handleAddFullPlaylistToPlaylist,
-      tooltip: context.l10n!.addToPlaylist,
-    );
-  }
-
-  void _handleAddFullPlaylistToPlaylist() {
-    if (_playlist != null && _playlist['list'] != null) {
-      final List<dynamic> tracks = _playlist['list'];
-      if (tracks.isEmpty) {
-        showToast(context, context.l10n!.noSongsInPlaylist);
-        return;
-      }
-      showAddToPlaylistDialog(context, songs: tracks);
-    } else {
-      showToast(context, context.l10n!.loading);
-    }
   }
 
   Widget _buildEditButton() {
@@ -534,6 +514,10 @@ class _PlaylistPageState extends State<PlaylistPage> {
         : isCachedPage
         ? await getPlaylistInfoForWidget(playlistId, forceRefresh: true)
         : await updatePlaylistList(context, playlistId);
+    if (updated?['catalogStatus'] == 'failed') {
+      if (mounted) showToast(context, context.l10n!.error);
+      return;
+    }
     if (updated != null && mounted) {
       setState(() {
         _playlist = updated;

--- a/lib/services/artist_service.dart
+++ b/lib/services/artist_service.dart
@@ -328,7 +328,7 @@ Future<Map<String, dynamic>?> _artistPageOf(
   }
 
   if (cacheResult) {
-    await cacheArtistProfile(artistProfile);
+    cacheArtistProfileInBackground(artistProfile);
   }
   return artistProfile;
 }
@@ -340,6 +340,18 @@ Future<void> cacheArtistProfile(Map artist) async {
     'cache',
     _artistProfileCacheKey(artistId),
     Map<String, dynamic>.from(artist),
+  );
+}
+
+void cacheArtistProfileInBackground(Map artist) {
+  unawaited(
+    cacheArtistProfile(artist).catchError((error, stackTrace) {
+      logger.log(
+        'Failed to cache artist profile',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }),
   );
 }
 
@@ -373,7 +385,7 @@ Future<Map<String, dynamic>?> getArtistCatalog(
     if (forceRefresh &&
         catalog != null &&
         catalog['catalogStatus'] != 'failed') {
-      await cacheArtistProfile(artist);
+      cacheArtistProfileInBackground(artist);
     }
     return catalog;
   } catch (e, stackTrace) {

--- a/lib/services/artist_service.dart
+++ b/lib/services/artist_service.dart
@@ -31,6 +31,7 @@ import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 import 'package:youtube_music_explode_dart/youtube_music_explode_dart.dart';
 
 final ytMusicClient = YoutubeMusicExplode();
+final Map<String, Future<void>> _artistCatalogOperationTails = {};
 
 Future<List<Map<String, dynamic>>> searchVerifiedArtists(
   String query, {
@@ -165,6 +166,7 @@ Future<Map<String, dynamic>?> resolveArtist(
 Future<Map<String, dynamic>?> getArtistProfile(
   String artistId, {
   bool forceRefresh = false,
+  bool cacheResult = true,
   String? sourceSongId,
   String? sourceVideoAuthor,
   String? preferredName,
@@ -187,6 +189,7 @@ Future<Map<String, dynamic>?> getArtistProfile(
       final profile = await _artistPageOf(
         knownChannel?.toString() ?? lookup,
         forceRefresh: forceRefresh,
+        cacheResult: cacheResult,
         preferredName: preferredName,
         preferredImage: preferredImage,
       );
@@ -217,6 +220,7 @@ Future<Map<String, dynamic>?> getArtistProfile(
     return await _artistPageOf(
       artist['ytid']?.toString() ?? lookup,
       forceRefresh: forceRefresh,
+      cacheResult: cacheResult,
       artist: artist,
     );
   } catch (e, stackTrace) {
@@ -238,6 +242,7 @@ Future<Map<String, dynamic>?> _artistPageOf(
   String? preferredName,
   String? preferredImage,
   bool followCanonical = true,
+  bool cacheResult = true,
 }) async {
   // Nothing is dropped before the page is in hand: a refresh that fails on a
   // bad connection would otherwise leave the artist with no page at all.
@@ -265,6 +270,7 @@ Future<Map<String, dynamic>?> _artistPageOf(
     return _artistPageOf(
       profile.id,
       forceRefresh: forceRefresh,
+      cacheResult: cacheResult,
       artist: artist,
       preferredName: preferredName,
       preferredImage: preferredImage,
@@ -307,7 +313,7 @@ Future<Map<String, dynamic>?> _artistPageOf(
     'releases': [
       for (final release in profile.releases)
         _releaseMapFromMusicAlbum(release, knownArtist),
-    ]..sort(_compareReleasesByYearDesc),
+    ],
     'relatedArtists': [
       for (final related in profile.relatedArtists)
         _artistMapFromMusicArtist(related),
@@ -321,13 +327,20 @@ Future<Map<String, dynamic>?> _artistPageOf(
     return artist == null ? null : artistProfile;
   }
 
-  if (forceRefresh) {
-    // The song catalog is built from this discography, so it went stale with
-    // it. It is rebuilt the next time the songs of the artist are needed.
-    await _dropFromCache(_artistCatalogCacheKey(artistId));
+  if (cacheResult) {
+    await cacheArtistProfile(artistProfile);
   }
-  unawaited(addOrUpdateData<Map>('cache', cacheKey, artistProfile));
   return artistProfile;
+}
+
+Future<void> cacheArtistProfile(Map artist) async {
+  final artistId = artist['ytid']?.toString();
+  if (artistId == null || artistId.isEmpty) return;
+  await addOrUpdateData<Map>(
+    'cache',
+    _artistProfileCacheKey(artistId),
+    Map<String, dynamic>.from(artist),
+  );
 }
 
 /// Artist catalog: all songs from the discography as a single playlist.
@@ -344,6 +357,7 @@ Future<Map<String, dynamic>?> getArtistCatalog(
     final artist = await getArtistProfile(
       artistId,
       forceRefresh: forceRefresh,
+      cacheResult: !forceRefresh,
       preferredName: preferredName,
       preferredImage: preferredImage,
       sourceSongId: sourceSongId,
@@ -352,32 +366,16 @@ Future<Map<String, dynamic>?> getArtistCatalog(
     );
     if (artist == null) return null;
 
-    // No [forceRefresh] check: refreshing the profile already dropped this key.
-    final cacheKey = _artistCatalogCacheKey(
-      artist['ytid']?.toString() ?? artistId,
+    final catalog = await getArtistCatalogFromProfile(
+      artist,
+      forceRebuild: forceRefresh,
     );
-    final cachedArtist = await getData('cache', cacheKey);
-    if (cachedArtist is Map &&
-        cachedArtist['list'] is List &&
-        (cachedArtist['list'] as List).isNotEmpty) {
-      return Map<String, dynamic>.from(cachedArtist);
+    if (forceRefresh &&
+        catalog != null &&
+        catalog['catalogStatus'] != 'failed') {
+      await cacheArtistProfile(artist);
     }
-
-    final songs = await _catalogSongsOf(artist);
-    if (songs.isEmpty) {
-      logger.log(
-        'Artist catalog empty: no YouTube Music releases for '
-        '${artist['title']} (${artist['ytid']}); lookup=$artistId',
-      );
-      return {
-        ...artistPlaylistData(artist, songs: const []),
-        'catalogStatus': 'failed',
-      };
-    }
-
-    final artistPlaylist = artistPlaylistData(artist, songs: songs);
-    unawaited(addOrUpdateData<Map>('cache', cacheKey, artistPlaylist));
-    return artistPlaylist;
+    return catalog;
   } catch (e, stackTrace) {
     logger.log(
       'Error fetching artist catalog for $artistId',
@@ -385,6 +383,106 @@ Future<Map<String, dynamic>?> getArtistCatalog(
       stackTrace: stackTrace,
     );
     return null;
+  }
+}
+
+/// Materializes the complete song catalog from a profile that was already
+/// loaded. This keeps refresh atomic: the landing page and the song list use
+/// the exact same release snapshot without reading the profile cache again.
+Future<Map<String, dynamic>?> getArtistCatalogFromProfile(
+  Map artist, {
+  bool forceRebuild = false,
+}) async {
+  final artistId = artist['ytid']?.toString();
+  if (artistId == null || artistId.isEmpty) return null;
+
+  return _serializeArtistCatalogOperation(
+    artistId,
+    () => _getArtistCatalogFromProfile(
+      artist,
+      artistId: artistId,
+      forceRebuild: forceRebuild,
+    ),
+  );
+}
+
+Future<Map<String, dynamic>?> _getArtistCatalogFromProfile(
+  Map artist, {
+  required String artistId,
+  required bool forceRebuild,
+}) async {
+  try {
+    final cacheKey = _artistCatalogCacheKey(artistId);
+    if (!forceRebuild) {
+      final cachedArtist = await getData('cache', cacheKey);
+      if (cachedArtist is Map &&
+          cachedArtist['list'] is List &&
+          (cachedArtist['list'] as List).isNotEmpty) {
+        return Map<String, dynamic>.from(cachedArtist);
+      }
+    }
+
+    final catalog = await _catalogSongsOf(Map<String, dynamic>.from(artist));
+    if ((forceRebuild && !catalog.isComplete) || catalog.songs.isEmpty) {
+      logger.log(
+        'Artist catalog incomplete: one or more YouTube Music releases could '
+        'not be read for ${artist['title']} ($artistId)',
+      );
+      return {
+        ...artistPlaylistData(artist, songs: const []),
+        'catalogStatus': 'failed',
+      };
+    }
+
+    if (!catalog.isComplete) {
+      logger.log(
+        'Artist catalog partially loaded for ${artist['title']} ($artistId)',
+      );
+    }
+
+    final artistPlaylist = artistPlaylistData(artist, songs: catalog.songs);
+    // A refresh may immediately read this key to update another view. Finish
+    // the local write before exposing the new catalog so stale data cannot win
+    // that race.
+    await addOrUpdateData<Map>('cache', cacheKey, artistPlaylist);
+    return artistPlaylist;
+  } catch (e, stackTrace) {
+    logger.log(
+      'Error building artist catalog from refreshed profile',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return null;
+  }
+}
+
+/// Runs catalog materializations for one artist in order. In particular, a
+/// normal action that started just before refresh must finish before the forced
+/// rebuild, so it cannot overwrite the fresh catalog after refresh completes.
+Future<T> _serializeArtistCatalogOperation<T>(
+  String artistId,
+  Future<T> Function() operation,
+) async {
+  final previous = _artistCatalogOperationTails[artistId];
+  final completion = Completer<void>();
+  final tail = completion.future;
+  _artistCatalogOperationTails[artistId] = tail;
+
+  if (previous != null) {
+    try {
+      await previous;
+    } catch (_) {
+      // The next materialization should still run after a failed predecessor.
+    }
+  }
+
+  try {
+    return await operation();
+  } finally {
+    completion.complete();
+    if (identical(_artistCatalogOperationTails[artistId], tail)) {
+      unawaited(_artistCatalogOperationTails.remove(artistId));
+    }
   }
 }
 
@@ -402,7 +500,7 @@ Map<String, dynamic> artistPlaylistData(Map artist, {List? songs}) {
 }
 
 /// Collects all songs from artist's discography in batches.
-Future<List<Map<String, dynamic>>> _catalogSongsOf(
+Future<({List<Map<String, dynamic>> songs, bool isComplete})> _catalogSongsOf(
   Map<String, dynamic> artist,
 ) async {
   final artistId = artist['ytid']?.toString();
@@ -410,14 +508,19 @@ Future<List<Map<String, dynamic>>> _catalogSongsOf(
   final releases = asMapList(artist['releases']);
 
   final songs = <Map<String, dynamic>>[];
+  var isComplete = true;
   for (var index = 0; index < releases.length; index += musicAlbumBatchSize) {
     final albums = await Future.wait([
       for (final release in releases.skip(index).take(musicAlbumBatchSize))
         getArtistAlbum(release['ytid']?.toString() ?? ''),
     ]);
     for (final album in albums) {
+      if (album == null) {
+        isComplete = false;
+        continue;
+      }
       // Credit songs to the artist, not the release owner (compilations, features)
-      for (final song in asMapList(album?['list'])) {
+      for (final song in asMapList(album['list'])) {
         songs.add({
           ...song,
           if (artistName.isNotEmpty) 'artist': artistName,
@@ -427,7 +530,7 @@ Future<List<Map<String, dynamic>>> _catalogSongsOf(
     }
   }
 
-  return dedupeArtistCatalogSongs(songs);
+  return (songs: dedupeArtistCatalogSongs(songs), isComplete: isComplete);
 }
 
 /// Load release as standalone playlist (crediting happens later in catalog builder).
@@ -518,13 +621,6 @@ Map<String, dynamic> _releaseMapFromMusicAlbum(MusicAlbum album, Map artist) {
     'source': 'youtube-album',
     'isAlbum': true,
   };
-}
-
-int _compareReleasesByYearDesc(Map<String, dynamic> a, Map<String, dynamic> b) {
-  final yearA = int.tryParse(a['year']?.toString() ?? '') ?? 0;
-  final yearB = int.tryParse(b['year']?.toString() ?? '') ?? 0;
-  if (yearA != yearB) return yearB.compareTo(yearA);
-  return (a['title']?.toString() ?? '').compareTo(b['title']?.toString() ?? '');
 }
 
 /// Reduces YouTube Music counters like `331M monthly audience` to `331M`.

--- a/lib/services/playlist_download_service.dart
+++ b/lib/services/playlist_download_service.dart
@@ -66,6 +66,15 @@ class OfflinePlaylistService {
     );
   }
 
+  Map? getOfflinePlaylist(String playlistId) {
+    for (final playlist in offlinePlaylists.value) {
+      if (playlist is Map && playlist['ytid']?.toString() == playlistId) {
+        return playlist;
+      }
+    }
+    return null;
+  }
+
   bool isPlaylistDownloading(String playlistId) {
     return activeDownloads.contains(playlistId);
   }

--- a/lib/services/playlists_manager.dart
+++ b/lib/services/playlists_manager.dart
@@ -1037,12 +1037,12 @@ Future<Map?> getPlaylistInfoForWidget(
   if (normalizedId.isEmpty || normalizedId == 'null') return null;
   if (isArtist) {
     final offlineArtist = _findOfflinePlaylist(normalizedId);
-    if (offlineArtist != null && (!forceRefresh || offlineMode.value)) {
-      return offlineArtist;
-    }
-    if (offlineMode.value) return null;
+    if (offlineMode.value) return offlineArtist;
 
-    return getArtistCatalog(
+    // An offline artist is a snapshot of the last successful download, not an
+    // online cache. Prefer the current catalog while online so a new release
+    // cannot disappear again immediately after the artist is refreshed.
+    final catalog = await getArtistCatalog(
       normalizedId,
       preferredName: artistName,
       preferredImage: artistImage,
@@ -1051,6 +1051,10 @@ Future<Map?> getPlaylistInfoForWidget(
       forceRefresh: forceRefresh,
       preferredVerified: preferredVerified,
     );
+    if (catalog == null || catalog['catalogStatus'] == 'failed') {
+      return forceRefresh ? catalog : offlineArtist ?? catalog;
+    }
+    return catalog;
   }
   if (normalizedId.startsWith('customId-')) {
     return _findCustomPlaylist(normalizedId)?.playlist;

--- a/lib/widgets/playlist_page/add_to_playlist_button.dart
+++ b/lib/widgets/playlist_page/add_to_playlist_button.dart
@@ -1,0 +1,98 @@
+/*
+ *     Copyright (C) 2026 Valeri Gokadze
+ *
+ *     Musify is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     Musify is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ *     For more information about Musify, including how to contribute,
+ *     please visit: https://github.com/gokadzev/Musify
+ */
+
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:musify/extensions/l10n.dart';
+import 'package:musify/utilities/flutter_toast.dart';
+import 'package:musify/utilities/playlist_dialogs.dart';
+
+/// Adds every song of a resolved playlist to one of the user's playlists.
+///
+/// The artist landing page only has its ranked songs on screen, so resolving
+/// on demand is what makes this action share the complete "All songs" catalog.
+class PlaylistAddToPlaylistButton extends StatefulWidget {
+  const PlaylistAddToPlaylistButton({super.key, required this.resolvePlaylist});
+
+  final Future<Map?> Function() resolvePlaylist;
+
+  @override
+  State<PlaylistAddToPlaylistButton> createState() =>
+      _PlaylistAddToPlaylistButtonState();
+}
+
+class _PlaylistAddToPlaylistButtonState
+    extends State<PlaylistAddToPlaylistButton> {
+  bool _isResolving = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isResolving) {
+      return const SizedBox(
+        width: 48,
+        height: 48,
+        child: Center(
+          child: SizedBox(
+            width: 24,
+            height: 24,
+            child: CircularProgressIndicator(strokeWidth: 3),
+          ),
+        ),
+      );
+    }
+
+    return IconButton.filledTonal(
+      icon: const Icon(FluentIcons.album_add_24_regular),
+      iconSize: 24,
+      onPressed: _resolveAndAdd,
+      tooltip: context.l10n!.addToPlaylist,
+    );
+  }
+
+  Future<void> _resolveAndAdd() async {
+    if (_isResolving) return;
+    setState(() => _isResolving = true);
+
+    Map? playlist;
+    try {
+      playlist = await widget.resolvePlaylist();
+    } catch (_) {
+      if (mounted) showToast(context, context.l10n!.error);
+      return;
+    } finally {
+      if (mounted) setState(() => _isResolving = false);
+    }
+    if (!mounted) return;
+
+    if (playlist == null || playlist['list'] is! List) {
+      showToast(context, context.l10n!.error);
+      return;
+    }
+
+    final songs = playlist['list'] as List;
+    if (songs.isEmpty) {
+      showToast(context, context.l10n!.noSongsInPlaylist);
+      return;
+    }
+
+    showAddToPlaylistDialog(context, songs: songs);
+  }
+}

--- a/lib/widgets/playlist_page/download_button.dart
+++ b/lib/widgets/playlist_page/download_button.dart
@@ -40,6 +40,7 @@ class PlaylistDownloadButton extends StatefulWidget {
     required this.playlistId,
     required this.resolvePlaylist,
     this.songs,
+    this.requireSnapshotMatch = false,
   });
 
   final String playlistId;
@@ -50,6 +51,11 @@ class PlaylistDownloadButton extends StatefulWidget {
   /// The songs already on screen, when the caller has the whole list. Without
   /// them the button falls back to whether the playlist was downloaded.
   final List? songs;
+
+  /// Also require the stored playlist snapshot to contain [songs]. Artists use
+  /// this after refresh so files downloaded through another playlist cannot
+  /// hide a newly discovered release.
+  final bool requireSnapshotMatch;
 
   @override
   State<PlaylistDownloadButton> createState() => _PlaylistDownloadButtonState();
@@ -63,9 +69,24 @@ class _PlaylistDownloadButtonState extends State<PlaylistDownloadButton> {
 
   String get playlistId => widget.playlistId;
 
-  bool get _isOffline => widget.songs != null
-      ? isPlaylistFullyOffline(widget.songs!)
-      : offlinePlaylistService.isPlaylistDownloaded(playlistId);
+  bool get _isOffline {
+    final songs = widget.songs;
+    if (songs == null) {
+      return offlinePlaylistService.isPlaylistDownloaded(playlistId);
+    }
+    if (!isPlaylistFullyOffline(songs)) return false;
+    if (!widget.requireSnapshotMatch) return true;
+
+    // The files may already exist because another playlist downloaded them.
+    // The artist itself is only current offline when its stored snapshot also
+    // contains every song of the catalog now on screen.
+    final snapshot = offlinePlaylistService.getOfflinePlaylist(playlistId);
+    if (snapshot == null) return false;
+    final snapshotIds = (snapshot['list'] as List? ?? const [])
+        .map((song) => song['ytid'])
+        .toSet();
+    return songs.every((song) => snapshotIds.contains(song['ytid']));
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Problem

The new artist landing page no longer exposes the previous All songs entry point. This caused two related regressions:

- users could no longer add the complete artist catalog to a playlist;
- downloaded artists could keep resolving to an older offline snapshot even while online.

Refreshing an artist updated the landing-page profile, but the complete catalog used by playback and downloads was not rebuilt atomically. A newly released song could appear on the page temporarily while later actions returned to the older downloaded catalog, leaving no reliable way to download the update.

## Changes

- add the existing full-playlist action to the artist landing page and resolve the complete artist catalog on demand;
- refresh the artist profile and complete catalog together, committing them only after the catalog was materialized successfully;
- prefer the current online artist catalog while online, using the downloaded snapshot only in offline mode or as a fallback for a normal failed lookup;
- retain one catalog snapshot for play, shuffle, add-to-playlist, and download actions;
- make the artist download action compare the refreshed catalog with both downloaded song files and the stored artist snapshot;
- preserve the source release order for same-year singles instead of using the title as a recency tie-breaker;
- ignore catalog resolutions that belong to an older refresh or a previously opened artist;
- preserve the previous artist state and cached catalog when a forced refresh is incomplete.

## Result

For a downloaded artist with catalog A:

1. the artist releases B;
2. the user refreshes the artist page;
3. the landing page and complete catalog become A + B;
4. the download action becomes available again;
5. downloading updates the artist snapshot and returns the action to the fully downloaded state.

This restores the update behavior already expected from regular playlists without adding a second artist download model.

## Validation

- flutter analyze --no-pub
- flutter build apk --debug --flavor github --no-pub
- deterministic local regression checks for A to A + B refreshes, incomplete catalog materialization, stale offline snapshots, existing files downloaded through another playlist, and same-year release ordering
- focused review of refresh failure and stale asynchronous result paths

## Out of scope

Top songs can reference a different YouTube video or release version than the corresponding album track. This change does not attempt to merge those identities, change the audio source, or download a separate landing-page catalog.