### PR TITLE
fix: make Spotify playlist import reliable and fast

### DIFF
--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -132,6 +132,8 @@
   "spotifyPlaylistInvalid": "The CSV does not contain Song and Artist columns",
   "spotifyPlaylistImporting": "Importing playlist...",
   "spotifyPlaylistImportResult": "{found} of {total} songs imported",
+  "spotifyPlaylistProgress": "Searching {done} of {total}",
+  "spotifyPlaylistAlreadyImporting": "An import is already in progress",
   "spotifyPlaylistMissingSongs": "Songs not found",
   "spotifyPlaylistImportFailed": "Playlist import failed",
   "invalidYouTubePlaylist": "Invalid YouTube playlist",

--- a/lib/screens/import_spotify_playlist_page.dart
+++ b/lib/screens/import_spotify_playlist_page.dart
@@ -5,11 +5,14 @@ import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/services.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:musify/extensions/l10n.dart';
-import 'package:musify/services/common_services.dart';
+import 'package:musify/main.dart' show logger;
+import 'package:musify/services/artist_service.dart' show ytMusicClient;
 import 'package:musify/services/playlists_manager.dart';
 import 'package:musify/utilities/flutter_toast.dart';
+import 'package:musify/utilities/formatter.dart';
 import 'package:musify/utilities/url_launcher.dart';
 import 'package:musify/widgets/mini_player.dart';
+import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
 class ImportSpotifyPlaylistPage extends StatefulWidget {
   const ImportSpotifyPlaylistPage({super.key});
@@ -20,10 +23,16 @@ class ImportSpotifyPlaylistPage extends StatefulWidget {
 }
 
 class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
+  // Shared across page instances so navigating away and reopening the page
+  // can't spawn a second import running concurrently with the first.
+  static bool _importRunning = false;
+
   final _csvController = TextEditingController();
   final _playlistNameController = TextEditingController();
   bool _isImporting = false;
   String? _fileName;
+  int _processedCount = 0;
+  int _totalCount = 0;
 
   @override
   void dispose() {
@@ -49,6 +58,10 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
 
   Future<void> _importPlaylist() async {
     if (_isImporting) return;
+    if (_importRunning) {
+      showToast(context, context.l10n!.spotifyPlaylistAlreadyImporting);
+      return;
+    }
     final playlistName = _playlistNameController.text.trim();
     if (playlistName.isEmpty) {
       showToast(context, context.l10n!.enterPlaylistName);
@@ -63,8 +76,19 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
     final headers = records.first
         .map((header) => header.replaceFirst('\ufeff', '').trim().toLowerCase())
         .toList();
-    final songIndex = headers.indexOf('song');
-    final artistIndex = headers.indexOf('artist');
+    bool isNameColumn(String header) =>
+        !header.contains('id') &&
+        !header.contains('uri') &&
+        !header.contains('url') &&
+        !header.contains('genre');
+    final songIndex = headers.indexWhere(
+      (header) =>
+          (header.contains('song') || header.contains('track')) &&
+          isNameColumn(header),
+    );
+    final artistIndex = headers.indexWhere(
+      (header) => header.contains('artist') && isNameColumn(header),
+    );
     if (songIndex == -1 || artistIndex == -1) {
       showToast(context, context.l10n!.spotifyPlaylistInvalid);
       return;
@@ -80,18 +104,62 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
       return;
     }
 
-    setState(() => _isImporting = true);
+    _importRunning = true;
+    setState(() {
+      _isImporting = true;
+      _processedCount = 0;
+      _totalCount = songs.length;
+    });
+
     final foundSongs = <Map>[];
     final missingSongs = <String>[];
-    for (final row in songs) {
-      final title = row[songIndex].trim();
-      final artist = row.length > artistIndex ? row[artistIndex].trim() : '';
-      final results = await fetchSongsList('$title $artist');
-      if (results.isEmpty) {
-        missingSongs.add('$title - $artist');
-      } else {
-        foundSongs.add(Map<String, dynamic>.from(results.first));
+    var rateLimited = false;
+    try {
+      const batchSize = 2;
+      for (var i = 0; i < songs.length; i += batchSize) {
+        final batch = songs.skip(i).take(batchSize).toList();
+        final batchResults = await Future.wait(
+          batch.map((row) async {
+            final title = row[songIndex].trim();
+            final artist = row.length > artistIndex
+                ? row[artistIndex].trim()
+                : '';
+            final (match, wasRateLimited) = await _findSongWithRetry(
+              '$title $artist',
+            );
+            return (title, artist, match, wasRateLimited);
+          }),
+        );
+        var batchRateLimited = false;
+        for (final (title, artist, match, wasRateLimited) in batchResults) {
+          if (wasRateLimited) batchRateLimited = true;
+          if (match == null) {
+            missingSongs.add('$title - $artist');
+          } else {
+            foundSongs.add(match);
+          }
+        }
+        if (mounted) setState(() => _processedCount += batchResults.length);
+        if (batchRateLimited) {
+          // YouTube is actively blocking this device; grinding through the
+          // rest of the playlist one retry at a time would just take
+          // forever, so stop early and hand back whatever was found so far.
+          rateLimited = true;
+          for (final row in songs.skip(i + batchSize)) {
+            final title = row[songIndex].trim();
+            final artist = row.length > artistIndex
+                ? row[artistIndex].trim()
+                : '';
+            missingSongs.add('$title - $artist');
+          }
+          break;
+        }
+        // Small pause between batches to avoid tripping YouTube's rate
+        // limiter in the first place.
+        await Future.delayed(const Duration(milliseconds: 400));
       }
+    } finally {
+      _importRunning = false;
     }
 
     if (!mounted) return;
@@ -99,10 +167,12 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
     addSongsInCustomPlaylist(context, playlistId, foundSongs);
     setState(() => _isImporting = false);
 
-    final resultText = context.l10n!.spotifyPlaylistImportResult(
-      foundSongs.length,
-      songs.length,
-    );
+    final resultText = rateLimited
+        ? '${context.l10n!.spotifyPlaylistImportFailed}\n${context.l10n!.spotifyPlaylistImportResult(foundSongs.length, songs.length)}'
+        : context.l10n!.spotifyPlaylistImportResult(
+            foundSongs.length,
+            songs.length,
+          );
     if (missingSongs.isNotEmpty) {
       final missingText = missingSongs.join('\n');
       await Clipboard.setData(ClipboardData(text: missingText));
@@ -119,6 +189,37 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
     } else {
       showToast(context, resultText);
     }
+  }
+
+  /// Returns the best match for [query], or `null` if none was found.
+  /// The second value is `true` when YouTube is actively rate-limiting this
+  /// device, so the caller can stop the whole import instead of retrying
+  /// every remaining song for minutes on end.
+  Future<(Map<String, dynamic>?, bool)> _findSongWithRetry(String query) async {
+    const maxAttempts = 2;
+    for (var attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        final video = await ytMusicClient.music.searchSong(query);
+        if (video == null) return (null, false);
+        return (Map<String, dynamic>.from(returnSongLayout(0, video)), false);
+      } on RequestLimitExceededException {
+        // A single short retry for a transient hiccup; a second hit means
+        // it's a genuine, sustained block.
+        if (attempt == maxAttempts - 1) return (null, true);
+        await Future.delayed(const Duration(seconds: 2));
+      } catch (e, stackTrace) {
+        if (attempt == maxAttempts - 1) {
+          logger.log(
+            'Error searching Spotify import match for "$query"',
+            error: e,
+            stackTrace: stackTrace,
+          );
+          return (null, false);
+        }
+        await Future.delayed(Duration(milliseconds: 500 * (attempt + 1)));
+      }
+    }
+    return (null, false);
   }
 
   List<List<String>> _parseCsv(String input) {
@@ -234,6 +335,24 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
                     : context.l10n!.importPlaylist,
               ),
             ),
+            if (_isImporting && _totalCount > 0) ...[
+              const SizedBox(height: 12),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: _processedCount / _totalCount,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                context.l10n!.spotifyPlaylistProgress(
+                  _processedCount,
+                  _totalCount,
+                ),
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
             const SizedBox(height: MiniPlayer.playerHeight + 24),
           ],
         ),

--- a/packages/youtube_explode_dart/lib/src/reverse_engineering/youtube_http_client.dart
+++ b/packages/youtube_explode_dart/lib/src/reverse_engineering/youtube_http_client.dart
@@ -296,8 +296,17 @@ class YoutubeHttpClient extends http.BaseClient {
       sendPost(action, {'continuation': token}, headers: headers);
 
   /// Sends a call to the youtube api endpoint.
-  Future<JsonMap> sendPost(String action, Map<String, dynamic> data,
-      {Map<String, String>? headers}) {
+  ///
+  /// [validate] defaults to `false` to preserve existing behavior for
+  /// callers that don't expect a thrown [RequestLimitExceededException] or
+  /// [FatalFailureException]; pass `true` to have those raised instead of
+  /// silently returning whatever body the server sent back.
+  Future<JsonMap> sendPost(
+    String action,
+    Map<String, dynamic> data, {
+    Map<String, String>? headers,
+    bool validate = false,
+  }) {
     assert(action == 'next' || action == 'browse' || action == 'search');
 
     final url = Uri.parse(
@@ -318,7 +327,12 @@ class YoutubeHttpClient extends http.BaseClient {
     };
 
     return retry<JsonMap>(this, () async {
-      final raw = await post(url, body: json.encode(body), headers: headers);
+      final raw = await post(
+        url,
+        body: json.encode(body),
+        headers: headers,
+        validate: validate,
+      );
       if (_closed) throw HttpClientClosedException();
 
       //final now = DateTime.now();

--- a/packages/youtube_music_explode_dart/lib/src/music_client.dart
+++ b/packages/youtube_music_explode_dart/lib/src/music_client.dart
@@ -209,6 +209,65 @@ class MusicClient {
     return results;
   }
 
+  /// Searches YouTube Music for a track matching [query] and returns the
+  /// best match, or `null` if nothing resolves to a playable video.
+  ///
+  /// Goes through the same `WEB_REMIX` browse/search endpoints as
+  /// [getArtistProfile] instead of the public search results page, which is
+  /// what keeps this from tripping YouTube's anti-scraping rate limiting the
+  /// way scraping `youtube.com/results` repeatedly does.
+  ///
+  /// Unlike an artist page's "Top songs" shelf, a search result row's second
+  /// column is a single `Song • Artist • Album` (or `Video • Channel •
+  /// Views`) line rather than a bare artist name, so it has to be split on
+  /// the bullet separator first.
+  Future<Video?> searchSong(String query) async {
+    final normalizedQuery = query.trim();
+    if (normalizedQuery.isEmpty) return null;
+
+    final root = await _httpClient.sendPost('search', {
+      'context': _remixContext,
+      'query': normalizedQuery,
+    }, validate: true);
+
+    Video? fallback;
+    for (final item in _findRenderers(
+      root,
+      'musicResponsiveListItemRenderer',
+    )) {
+      final videoId = _trackVideoId(item);
+      if (videoId == null) continue;
+
+      final title = _flexColumnText(item, 0);
+      if (title == null || title.isEmpty) continue;
+
+      final subtitleParts = _splitBullets(_flexColumnText(item, 1));
+      final type = subtitleParts.isNotEmpty
+          ? subtitleParts.first.toLowerCase()
+          : '';
+      final artist = subtitleParts.length >= 2
+          ? subtitleParts[1]
+          : (subtitleParts.isNotEmpty ? subtitleParts.first : '');
+
+      final video = _trackVideo(item, videoId, title, artist, null);
+      // Prefer a canonical "Song" row over a "Video"/other row further down.
+      if (type == 'song') return video;
+      fallback ??= video;
+    }
+    return fallback;
+  }
+
+  /// Splits a `Song • Artist • Album` style subtitle line on its bullet
+  /// separators.
+  List<String> _splitBullets(String? text) {
+    if (text == null) return const [];
+    return text
+        .split('•')
+        .map((part) => part.trim())
+        .where((part) => part.isNotEmpty)
+        .toList();
+  }
+
   /// Returns a YouTube Music artist page: header details, top songs, the full
   /// discography and the artists it points to.
   ///


### PR DESCRIPTION
## Problem

The new [BETA] Spotify CSV import (from #914/#370/#371) searches YouTube once per song via `ytClient.search.search`, which scrapes the public `youtube.com/results` page. On a real device this showed up as three concrete bugs:

1. **Very slow.** A ~150-song playlist took over 30 minutes and only imported ~55 songs before the run was effectively stuck.
2. **Rarely imports everything**, even accounting for genuinely-missing tracks — most of the loss was silent failures, not "song not found."
3. **A friend hit an outright error on a different device** with a CSV that had slightly different column names (e.g. `Artist Name(s)` / `Track Name` instead of the exact `song`/`artist` the parser required), which surfaced as "CSV does not contain Song and Artist columns" even though the data was there.

## Root cause

Scraping `youtube.com/results` is exactly the traffic pattern YouTube's anti-scraping throttling watches for — a handful of rapid searches from the same client can trip a `429`/`/sorry/` response. The artist page (added in #904) never hits this because it talks to YouTube Music's internal `WEB_REMIX` InnerTube endpoints instead of scraping the search page.

## Approaches tried, in order

- **Concurrency alone (batch of 5 searches in parallel).** Made the rate limiting *worse* — 5 simultaneous scrape requests tripped the throttle almost immediately, then every retry hit the same wall.
- **Smaller batch (2) + longer per-item backoff (up to 9s).** Avoided the immediate flood, but once actually throttled, grinding through the rest of a large playlist one slow retry at a time was still effectively a 20+ minute hang with no feedback — same failure, just slower to arrive at.
- **Switch the search itself to the WEB_REMIX InnerTube endpoints** (`MusicClient.searchSong`, new method, same client the artist page already uses) instead of scraping search results. This is the actual fix — it doesn't trip the same throttling in the first place. Kept small batching (2 at a time, short pause between batches) as a second line of defense, plus a circuit breaker that stops the import early and hands back whatever was found so far if YouTube still throttles the device, instead of retrying every remaining song for minutes on end.
- While building `searchSong`, found and fixed two bugs specific to a *search* row's shape (as opposed to an artist page's "Top songs" shelf row): (a) a search result's second column is a bullet-joined `Song • Artist • Album` (or `Video • Channel • Views`) string rather than a bare artist name, so the artist field was showing garbage like "Video • 1.2M views" until it's split on the bullet separator; (b) the first playable item found could be a "Video" result instead of a canonical "Song," so it now prefers a `Song`-typed row when one exists.
- `YoutubeHttpClient.sendPost` never validated response status codes, so a genuine rate-limit response on this new endpoint wouldn't have been distinguishable from "no results" — added an opt-in `validate` parameter (defaults to `false`, every existing caller unaffected) so the new search path can actually detect and react to a real `429`.

## Other fixes in this PR

- Live "X of Y" progress during the import (previously just a spinner with no way to tell if it had frozen).
- Guards against starting a second import concurrently (e.g. by leaving and reopening the page) while one is already running.
- CSV header matching now accepts common variants (`Track Name`, `Artist Name(s)`, etc.) instead of requiring the exact columns `song`/`artist`, while excluding ID/URI/genre columns that happen to also contain those words — this is what caused the friend's device error.

## Test plan

- [x] `dart analyze` clean on all touched files
- [x] Manually tested on a physical Android device (`--flavor github`): imported CSVs of ~90 and ~130 songs, verified progress UI, verified a duplicate-import attempt is blocked, verified graceful early-stop behavior under YouTube rate limiting
- [x] Confirmed the artist page's existing calls into `MusicClient`/`sendPost` are unaffected — reviewed every call site, only the new `searchSong` passes `validate: true`