### PR TITLE
fix: correct wrong matches and speed up the Spotify CSV import

### DIFF
--- a/lib/screens/import_spotify_playlist_page.dart
+++ b/lib/screens/import_spotify_playlist_page.dart
@@ -27,6 +27,12 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
   // can't spawn a second import running concurrently with the first.
   static bool _importRunning = false;
 
+  // Kept well under the ~24-concurrent ceiling a rate-limit probe against
+  // the Songs-shelf search endpoint ran clean at (500 requests, no
+  // throttling) — plenty of headroom for real-world query variance.
+  static const _batchSize = 12;
+  static const _batchPause = Duration(milliseconds: 150);
+
   final _csvController = TextEditingController();
   final _playlistNameController = TextEditingController();
   bool _isImporting = false;
@@ -181,11 +187,15 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
     }
   }
 
-  /// Resolves every (title, artist) pair in [rows] to a song, in small
-  /// batches with a pause between them to avoid tripping YouTube's rate
-  /// limiter. Stops early — leaving the rest of [rows] in `missing` — the
-  /// moment a batch reports active rate-limiting, rather than retrying the
-  /// remainder one at a time for minutes on end.
+  /// Resolves every (title, artist) pair in [rows] to a song, in batches
+  /// with a short pause between them. The Songs-shelf search endpoint
+  /// tolerates far more concurrency than the scraped search this import
+  /// used to run through — 500 back-to-back probe requests at up to 24
+  /// concurrent never got rate-limited — so [_batchSize]/[_batchPause] stay
+  /// well under that ceiling rather than at the old scraper's pace. Stops
+  /// early — leaving the rest of [rows] in `missing` — the moment a batch
+  /// reports active rate-limiting, rather than retrying the remainder one
+  /// at a time for minutes on end.
   Future<
     ({
       List<Map> found,
@@ -197,11 +207,10 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
     List<({String title, String artist})> rows, {
     required void Function(int processedCount) onProgress,
   }) async {
-    const batchSize = 2;
     final found = <Map>[];
     final missing = <({String title, String artist})>[];
-    for (var i = 0; i < rows.length; i += batchSize) {
-      final batch = rows.skip(i).take(batchSize).toList();
+    for (var i = 0; i < rows.length; i += _batchSize) {
+      final batch = rows.skip(i).take(_batchSize).toList();
       final batchResults = await Future.wait(
         batch.map((row) async {
           final (match, wasRateLimited) = await _findSongWithRetry(
@@ -223,12 +232,10 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
       }
       onProgress(batchResults.length);
       if (batchRateLimited) {
-        missing.addAll(rows.skip(i + batchSize));
+        missing.addAll(rows.skip(i + _batchSize));
         return (found: found, missing: missing, rateLimited: true);
       }
-      // Small pause between batches to avoid tripping YouTube's rate
-      // limiter in the first place.
-      await Future.delayed(const Duration(milliseconds: 400));
+      await Future.delayed(_batchPause);
     }
     return (found: found, missing: missing, rateLimited: false);
   }

--- a/lib/screens/import_spotify_playlist_page.dart
+++ b/lib/screens/import_spotify_playlist_page.dart
@@ -14,6 +14,11 @@ import 'package:musify/utilities/url_launcher.dart';
 import 'package:musify/widgets/mini_player.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
+/// One CSV row's song/artist text plus its original position in the file,
+/// so results from separate search passes (a retry over misses, in
+/// particular) can still be placed back in CSV order.
+typedef _ImportRow = ({int index, String title, String artist});
+
 class ImportSpotifyPlaylistPage extends StatefulWidget {
   const ImportSpotifyPlaylistPage({super.key});
 
@@ -110,11 +115,14 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
       return;
     }
 
-    final rows = songs
+    // Every row here already satisfies `row.length > artistIndex` per the
+    // filter above.
+    final rows = songs.indexed
         .map(
-          (row) => (
-            title: row[songIndex].trim(),
-            artist: row.length > artistIndex ? row[artistIndex].trim() : '',
+          (entry) => (
+            index: entry.$1,
+            title: entry.$2[songIndex].trim(),
+            artist: entry.$2[artistIndex].trim(),
           ),
         )
         .toList();
@@ -126,8 +134,11 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
       _totalCount = rows.length;
     });
 
-    List<Map> foundSongs;
-    List<({String title, String artist})> missingRows;
+    // Keyed by each row's original CSV position so a song recovered on the
+    // retry pass still lands where it belongs in the imported playlist,
+    // instead of getting appended after everything the first pass found.
+    final foundByIndex = <int, Map>{};
+    List<_ImportRow> missingRows;
     var rateLimited = false;
     try {
       final firstPass = await _searchBatch(
@@ -136,7 +147,7 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
           if (mounted) setState(() => _processedCount += n);
         },
       );
-      foundSongs = firstPass.found;
+      foundByIndex.addAll(firstPass.found);
       missingRows = firstPass.missing;
       rateLimited = firstPass.rateLimited;
 
@@ -147,14 +158,28 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
       // unless YouTube is actively rate-limiting the device, in which case
       // grinding through it again would just make things worse.
       if (!rateLimited && missingRows.isNotEmpty) {
-        final retryPass = await _searchBatch(missingRows, onProgress: (_) {});
-        foundSongs = [...foundSongs, ...retryPass.found];
+        // The bar was already full after the first pass; stretch the total
+        // so a retry pass still visibly moves it instead of just sitting at
+        // 100% while work keeps happening.
+        if (mounted) setState(() => _totalCount += missingRows.length);
+        final retryPass = await _searchBatch(
+          missingRows,
+          onProgress: (n) {
+            if (mounted) setState(() => _processedCount += n);
+          },
+        );
+        foundByIndex.addAll(retryPass.found);
         missingRows = retryPass.missing;
         rateLimited = retryPass.rateLimited;
       }
     } finally {
       _importRunning = false;
     }
+
+    final foundSongs = [
+      for (final row in rows)
+        if (foundByIndex[row.index] case final song?) song,
+    ];
 
     if (!mounted) return;
     final (_, playlistId) = createCustomPlaylist(playlistName, null, context);
@@ -187,28 +212,24 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
     }
   }
 
-  /// Resolves every (title, artist) pair in [rows] to a song, in batches
-  /// with a short pause between them. The Songs-shelf search endpoint
-  /// tolerates far more concurrency than the scraped search this import
-  /// used to run through — 500 back-to-back probe requests at up to 24
-  /// concurrent never got rate-limited — so [_batchSize]/[_batchPause] stay
-  /// well under that ceiling rather than at the old scraper's pace. Stops
-  /// early — leaving the rest of [rows] in `missing` — the moment a batch
-  /// reports active rate-limiting, rather than retrying the remainder one
-  /// at a time for minutes on end.
-  Future<
-    ({
-      List<Map> found,
-      List<({String title, String artist})> missing,
-      bool rateLimited,
-    })
-  >
+  /// Resolves every row in [rows] to a song, in batches with a short pause
+  /// between them. The Songs-shelf search endpoint tolerates far more
+  /// concurrency than the scraped search this import used to run through —
+  /// 500 back-to-back probe requests at up to 24 concurrent never got
+  /// rate-limited — so [_batchSize]/[_batchPause] stay well under that
+  /// ceiling rather than at the old scraper's pace. Stops early — leaving
+  /// the rest of [rows] in `missing` — the moment a batch reports active
+  /// rate-limiting, rather than retrying the remainder one at a time for
+  /// minutes on end. `found` is keyed by each row's original index so a
+  /// caller merging results from more than one pass (e.g. a retry over
+  /// just the misses) can still place them at their original position.
+  Future<({Map<int, Map> found, List<_ImportRow> missing, bool rateLimited})>
   _searchBatch(
-    List<({String title, String artist})> rows, {
+    List<_ImportRow> rows, {
     required void Function(int processedCount) onProgress,
   }) async {
-    final found = <Map>[];
-    final missing = <({String title, String artist})>[];
+    final found = <int, Map>{};
+    final missing = <_ImportRow>[];
     for (var i = 0; i < rows.length; i += _batchSize) {
       final batch = rows.skip(i).take(_batchSize).toList();
       final batchResults = await Future.wait(
@@ -227,7 +248,7 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
         if (match == null) {
           missing.add(row);
         } else {
-          found.add(match);
+          found[row.index] = match;
         }
       }
       onProgress(batchResults.length);

--- a/lib/screens/import_spotify_playlist_page.dart
+++ b/lib/screens/import_spotify_playlist_page.dart
@@ -104,61 +104,47 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
       return;
     }
 
+    final rows = songs
+        .map(
+          (row) => (
+            title: row[songIndex].trim(),
+            artist: row.length > artistIndex ? row[artistIndex].trim() : '',
+          ),
+        )
+        .toList();
+
     _importRunning = true;
     setState(() {
       _isImporting = true;
       _processedCount = 0;
-      _totalCount = songs.length;
+      _totalCount = rows.length;
     });
 
-    final foundSongs = <Map>[];
-    final missingSongs = <String>[];
+    List<Map> foundSongs;
+    List<({String title, String artist})> missingRows;
     var rateLimited = false;
     try {
-      const batchSize = 2;
-      for (var i = 0; i < songs.length; i += batchSize) {
-        final batch = songs.skip(i).take(batchSize).toList();
-        final batchResults = await Future.wait(
-          batch.map((row) async {
-            final title = row[songIndex].trim();
-            final artist = row.length > artistIndex
-                ? row[artistIndex].trim()
-                : '';
-            final (match, wasRateLimited) = await _findSongWithRetry(
-              '$title $artist',
-              expectedArtist: artist,
-              expectedTitle: title,
-            );
-            return (title, artist, match, wasRateLimited);
-          }),
-        );
-        var batchRateLimited = false;
-        for (final (title, artist, match, wasRateLimited) in batchResults) {
-          if (wasRateLimited) batchRateLimited = true;
-          if (match == null) {
-            missingSongs.add('$title - $artist');
-          } else {
-            foundSongs.add(match);
-          }
-        }
-        if (mounted) setState(() => _processedCount += batchResults.length);
-        if (batchRateLimited) {
-          // YouTube is actively blocking this device; grinding through the
-          // rest of the playlist one retry at a time would just take
-          // forever, so stop early and hand back whatever was found so far.
-          rateLimited = true;
-          for (final row in songs.skip(i + batchSize)) {
-            final title = row[songIndex].trim();
-            final artist = row.length > artistIndex
-                ? row[artistIndex].trim()
-                : '';
-            missingSongs.add('$title - $artist');
-          }
-          break;
-        }
-        // Small pause between batches to avoid tripping YouTube's rate
-        // limiter in the first place.
-        await Future.delayed(const Duration(milliseconds: 400));
+      final firstPass = await _searchBatch(
+        rows,
+        onProgress: (n) {
+          if (mounted) setState(() => _processedCount += n);
+        },
+      );
+      foundSongs = firstPass.found;
+      missingRows = firstPass.missing;
+      rateLimited = firstPass.rateLimited;
+
+      // A miss is often just a transient dip in search quality rather than
+      // a real absence (see the "Ato 1" import, where songs like "Toxic" or
+      // "Hurt" failed mid-run but matched fine moments later), so give the
+      // whole batch of misses one more pass once things have settled —
+      // unless YouTube is actively rate-limiting the device, in which case
+      // grinding through it again would just make things worse.
+      if (!rateLimited && missingRows.isNotEmpty) {
+        final retryPass = await _searchBatch(missingRows, onProgress: (_) {});
+        foundSongs = [...foundSongs, ...retryPass.found];
+        missingRows = retryPass.missing;
+        rateLimited = retryPass.rateLimited;
       }
     } finally {
       _importRunning = false;
@@ -170,13 +156,15 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
     setState(() => _isImporting = false);
 
     final resultText = rateLimited
-        ? '${context.l10n!.spotifyPlaylistImportFailed}\n${context.l10n!.spotifyPlaylistImportResult(foundSongs.length, songs.length)}'
+        ? '${context.l10n!.spotifyPlaylistImportFailed}\n${context.l10n!.spotifyPlaylistImportResult(foundSongs.length, rows.length)}'
         : context.l10n!.spotifyPlaylistImportResult(
             foundSongs.length,
-            songs.length,
+            rows.length,
           );
-    if (missingSongs.isNotEmpty) {
-      final missingText = missingSongs.join('\n');
+    if (missingRows.isNotEmpty) {
+      final missingText = missingRows
+          .map((row) => '${row.title} - ${row.artist}')
+          .join('\n');
       await Clipboard.setData(ClipboardData(text: missingText));
       if (mounted) {
         showToastWithButton(
@@ -191,6 +179,58 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
     } else {
       showToast(context, resultText);
     }
+  }
+
+  /// Resolves every (title, artist) pair in [rows] to a song, in small
+  /// batches with a pause between them to avoid tripping YouTube's rate
+  /// limiter. Stops early — leaving the rest of [rows] in `missing` — the
+  /// moment a batch reports active rate-limiting, rather than retrying the
+  /// remainder one at a time for minutes on end.
+  Future<
+    ({
+      List<Map> found,
+      List<({String title, String artist})> missing,
+      bool rateLimited,
+    })
+  >
+  _searchBatch(
+    List<({String title, String artist})> rows, {
+    required void Function(int processedCount) onProgress,
+  }) async {
+    const batchSize = 2;
+    final found = <Map>[];
+    final missing = <({String title, String artist})>[];
+    for (var i = 0; i < rows.length; i += batchSize) {
+      final batch = rows.skip(i).take(batchSize).toList();
+      final batchResults = await Future.wait(
+        batch.map((row) async {
+          final (match, wasRateLimited) = await _findSongWithRetry(
+            '${row.title} ${row.artist}',
+            expectedArtist: row.artist,
+            expectedTitle: row.title,
+          );
+          return (row, match, wasRateLimited);
+        }),
+      );
+      var batchRateLimited = false;
+      for (final (row, match, wasRateLimited) in batchResults) {
+        if (wasRateLimited) batchRateLimited = true;
+        if (match == null) {
+          missing.add(row);
+        } else {
+          found.add(match);
+        }
+      }
+      onProgress(batchResults.length);
+      if (batchRateLimited) {
+        missing.addAll(rows.skip(i + batchSize));
+        return (found: found, missing: missing, rateLimited: true);
+      }
+      // Small pause between batches to avoid tripping YouTube's rate
+      // limiter in the first place.
+      await Future.delayed(const Duration(milliseconds: 400));
+    }
+    return (found: found, missing: missing, rateLimited: false);
   }
 
   /// Returns the best match for [query], or `null` if none was found.

--- a/lib/screens/import_spotify_playlist_page.dart
+++ b/lib/screens/import_spotify_playlist_page.dart
@@ -126,6 +126,8 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
                 : '';
             final (match, wasRateLimited) = await _findSongWithRetry(
               '$title $artist',
+              expectedArtist: artist,
+              expectedTitle: title,
             );
             return (title, artist, match, wasRateLimited);
           }),
@@ -195,11 +197,19 @@ class _ImportSpotifyPlaylistPageState extends State<ImportSpotifyPlaylistPage> {
   /// The second value is `true` when YouTube is actively rate-limiting this
   /// device, so the caller can stop the whole import instead of retrying
   /// every remaining song for minutes on end.
-  Future<(Map<String, dynamic>?, bool)> _findSongWithRetry(String query) async {
+  Future<(Map<String, dynamic>?, bool)> _findSongWithRetry(
+    String query, {
+    String? expectedArtist,
+    String? expectedTitle,
+  }) async {
     const maxAttempts = 2;
     for (var attempt = 0; attempt < maxAttempts; attempt++) {
       try {
-        final video = await ytMusicClient.music.searchSong(query);
+        final video = await ytMusicClient.music.searchSong(
+          query,
+          expectedArtist: expectedArtist,
+          expectedTitle: expectedTitle,
+        );
         if (video == null) return (null, false);
         return (Map<String, dynamic>.from(returnSongLayout(0, video)), false);
       } on RequestLimitExceededException {

--- a/packages/youtube_music_explode_dart/lib/src/music_client.dart
+++ b/packages/youtube_music_explode_dart/lib/src/music_client.dart
@@ -162,27 +162,6 @@ class MusicClient {
   /// differently-titled track above the actual song.
   static const _songsSearchParams = 'EgWKAQIIAWoMEA4QChADEAQQCRAF';
 
-  /// Words that mark a title as a different recording than the plain
-  /// original (a live take, a remix, a cover...). A candidate carrying one
-  /// of these that the searched-for title doesn't is rejected even though
-  /// it's a loose substring match — otherwise "Bad" matches "Bad (Live)"
-  /// since "Bad" is literally a substring of it.
-  static const _alternateVersionKeywords = [
-    'live',
-    'remix',
-    'karaoke',
-    'karaokê',
-    'cover',
-    'acoustic',
-    'unplugged',
-    'instrumental',
-    'demo',
-    'rehearsal',
-    'session',
-    'reprise',
-    'tribute',
-  ];
-
   static const _artistPageType = 'MUSIC_PAGE_TYPE_ARTIST';
 
   /// Stands in for the channel of a track whose artist page is unknown.
@@ -255,17 +234,17 @@ class MusicClient {
   /// type label to skip.
   ///
   /// [expectedArtist] and [expectedTitle], when given, reject any row whose
-  /// credited artist or title doesn't match them closely enough (see
-  /// [_looselyMatch] and [_titleMatches]) instead of trusting YouTube
-  /// Music's top result blindly. This matters for callers matching a known
-  /// (title, artist) pair — e.g. a Spotify CSV import — where a viral
-  /// cover/remix of a common title can otherwise rank above the original
-  /// (wrong artist, matching title), checking the artist alone isn't enough
-  /// either since the next-best same-artist result can just as easily be a
-  /// different song by them (matching artist, wrong title), and even a
-  /// title that matches by substring can still be a live/remix/cover
-  /// recording rather than the original. All three checks together bring
-  /// the risk down to "no result" rather than any of those wrong ones.
+  /// credited artist or title doesn't loosely match them (see
+  /// [_looselyMatch]) instead of trusting YouTube Music's top result
+  /// blindly. This matters for callers matching a known (title, artist)
+  /// pair — e.g. a Spotify CSV import — where a viral cover/remix of a
+  /// common title can otherwise rank above the original (wrong artist,
+  /// matching title), and checking the artist alone isn't enough either:
+  /// the next-best same-artist result can just as easily be a completely
+  /// different song by them (matching artist, wrong title). A CSV row that
+  /// itself asks for a specific recording (its title says "Live" or
+  /// "Remix") still gets it, since that's now part of the expected title
+  /// being matched against.
   Future<Video?> searchSong(
     String query, {
     String? expectedArtist,
@@ -301,7 +280,7 @@ class MusicClient {
       if (expectedArtist != null && !_looselyMatch(artist, expectedArtist)) {
         continue;
       }
-      if (expectedTitle != null && !_titleMatches(title, expectedTitle)) {
+      if (expectedTitle != null && !_looselyMatch(title, expectedTitle)) {
         continue;
       }
 
@@ -337,24 +316,6 @@ class MusicClient {
     final b = _normalizeForMatch(expected);
     if (a.isEmpty || b.isEmpty) return true;
     return a.contains(b) || b.contains(a);
-  }
-
-  /// Like [_looselyMatch], but additionally rejects a candidate title that
-  /// carries an [_alternateVersionKeywords] word the expected title doesn't
-  /// — e.g. expected "Mother" doesn't accept candidate "Mother (Live 1989)"
-  /// just because "mother" is a substring of it.
-  bool _titleMatches(String candidate, String expected) {
-    if (!_looselyMatch(candidate, expected)) return false;
-
-    final candidateWords = _normalizeForMatch(candidate).split(' ').toSet();
-    final expectedWords = _normalizeForMatch(expected).split(' ').toSet();
-    for (final keyword in _alternateVersionKeywords) {
-      if (candidateWords.contains(keyword) &&
-          !expectedWords.contains(keyword)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   String _normalizeForMatch(String input) => input

--- a/packages/youtube_music_explode_dart/lib/src/music_client.dart
+++ b/packages/youtube_music_explode_dart/lib/src/music_client.dart
@@ -327,12 +327,60 @@ class MusicClient {
     return shorter.every(longer.contains);
   }
 
-  Set<String> _wordsForMatch(String input) => input
-      .toLowerCase()
-      .replaceAll(RegExp(r'[^\w\s]'), ' ')
-      .split(RegExp(r'\s+'))
-      .where((word) => word.isNotEmpty)
-      .toSet();
+  Set<String> _wordsForMatch(String input) =>
+      _foldDiacritics(input.toLowerCase())
+          // `\w` is ASCII-only, so anchoring on it here would strip Cyrillic/
+          // CJK/etc. text down to nothing on both sides and silently disable
+          // matching entirely (both sides empty → the isEmpty check above just
+          // waves it through). `\p{L}`/`\p{N}` (any Unicode letter/number) keep
+          // non-Latin scripts intact while still stripping real punctuation.
+          .replaceAll(RegExp(r'[^\p{L}\p{N}\s]', unicode: true), ' ')
+          .split(RegExp(r'\s+'))
+          .where((word) => word.isNotEmpty)
+          .toSet();
+
+  /// Folds common Latin accented letters to their base form (e.g. "é" → "e")
+  /// so a CSV's plain-ASCII spelling of an accented title/artist still
+  /// matches YouTube Music's accented one, and vice versa. Scripts outside
+  /// this table (Cyrillic, CJK, Arabic...) pass through untouched.
+  String _foldDiacritics(String input) {
+    final buffer = StringBuffer();
+    for (final rune in input.runes) {
+      final char = String.fromCharCode(rune);
+      buffer.write(_diacriticFold[char] ?? char);
+    }
+    return buffer.toString();
+  }
+
+  static const _diacriticFold = {
+    'á': 'a',
+    'à': 'a',
+    'â': 'a',
+    'ã': 'a',
+    'ä': 'a',
+    'å': 'a',
+    'é': 'e',
+    'è': 'e',
+    'ê': 'e',
+    'ë': 'e',
+    'í': 'i',
+    'ì': 'i',
+    'î': 'i',
+    'ï': 'i',
+    'ó': 'o',
+    'ò': 'o',
+    'ô': 'o',
+    'õ': 'o',
+    'ö': 'o',
+    'ú': 'u',
+    'ù': 'u',
+    'û': 'u',
+    'ü': 'u',
+    'ý': 'y',
+    'ÿ': 'y',
+    'ç': 'c',
+    'ñ': 'n',
+  };
 
   /// Returns a YouTube Music artist page: header details, top songs, the full
   /// discography and the artists it points to.

--- a/packages/youtube_music_explode_dart/lib/src/music_client.dart
+++ b/packages/youtube_music_explode_dart/lib/src/music_client.dart
@@ -305,24 +305,34 @@ class MusicClient {
   }
 
   /// Loose match used to reject a search row whose title or credited artist
-  /// clearly isn't the one being searched for. Both sides are compared by
-  /// substring containment after stripping punctuation, so e.g. "Arctic
-  /// Monkeys" matches "Arctic Monkeys", and "Sia" matches a row crediting
-  /// the multi-artist string "Sia & Diplo". An empty/unparseable side
-  /// doesn't block a match, since that just means the row didn't carry a
-  /// usable string to check in the first place.
+  /// clearly isn't the one being searched for. Compares the two as *sets*
+  /// of normalized words rather than as ordered text, so it doesn't care
+  /// about word order or connector words — only whether the shorter side's
+  /// words are all present on the longer side. That one rule is what makes
+  /// "Arctic Monkeys" match "Arctic Monkeys", "Sia" match a row crediting
+  /// "Sia & Diplo", a comma-joined CSV artist list ("Queen,David Bowie")
+  /// match YouTube Music's own "Queen & David Bowie" or "Hugo e Guilherme"
+  /// (Portuguese) credit for the same track, and a title with a
+  /// differently-placed qualifier ("love nwantiti (Remix) (feat. ...)" vs
+  /// "love nwantiti (feat. ...) - Remix") still match — without hand-coding
+  /// each connector word or language. An empty/unparseable side doesn't
+  /// block a match, since that just means the row didn't carry a usable
+  /// string to check in the first place.
   bool _looselyMatch(String candidate, String expected) {
-    final a = _normalizeForMatch(candidate);
-    final b = _normalizeForMatch(expected);
+    final a = _wordsForMatch(candidate);
+    final b = _wordsForMatch(expected);
     if (a.isEmpty || b.isEmpty) return true;
-    return a.contains(b) || b.contains(a);
+    final shorter = a.length <= b.length ? a : b;
+    final longer = identical(shorter, a) ? b : a;
+    return shorter.every(longer.contains);
   }
 
-  String _normalizeForMatch(String input) => input
+  Set<String> _wordsForMatch(String input) => input
       .toLowerCase()
       .replaceAll(RegExp(r'[^\w\s]'), ' ')
-      .replaceAll(RegExp(r'\s+'), ' ')
-      .trim();
+      .split(RegExp(r'\s+'))
+      .where((word) => word.isNotEmpty)
+      .toSet();
 
   /// Returns a YouTube Music artist page: header details, top songs, the full
   /// discography and the artists it points to.

--- a/packages/youtube_music_explode_dart/lib/src/music_client.dart
+++ b/packages/youtube_music_explode_dart/lib/src/music_client.dart
@@ -154,6 +154,35 @@ class MusicClient {
   /// Search filter that restricts results to artists only.
   static const _artistsSearchParams = 'EgWKAQIgAWoMEA4QChADEAQQCRAF';
 
+  /// Search filter that restricts results to the dedicated "Songs" shelf
+  /// (same encoding as [_artistsSearchParams], `II` in place of `Ig`).
+  /// Scored candidates only, no cross-category noise from videos/albums/
+  /// artists sharing the query — which is also what keeps a query like
+  /// "Bad Michael Jackson" from surfacing a live recording or a
+  /// differently-titled track above the actual song.
+  static const _songsSearchParams = 'EgWKAQIIAWoMEA4QChADEAQQCRAF';
+
+  /// Words that mark a title as a different recording than the plain
+  /// original (a live take, a remix, a cover...). A candidate carrying one
+  /// of these that the searched-for title doesn't is rejected even though
+  /// it's a loose substring match — otherwise "Bad" matches "Bad (Live)"
+  /// since "Bad" is literally a substring of it.
+  static const _alternateVersionKeywords = [
+    'live',
+    'remix',
+    'karaoke',
+    'karaokê',
+    'cover',
+    'acoustic',
+    'unplugged',
+    'instrumental',
+    'demo',
+    'rehearsal',
+    'session',
+    'reprise',
+    'tribute',
+  ];
+
   static const _artistPageType = 'MUSIC_PAGE_TYPE_ARTIST';
 
   /// Stands in for the channel of a track whose artist page is unknown.
@@ -209,30 +238,34 @@ class MusicClient {
     return results;
   }
 
-  /// Searches YouTube Music for a track matching [query] and returns the
-  /// best match, or `null` if nothing resolves to a playable video.
+  /// Searches YouTube Music's dedicated "Songs" shelf for a track matching
+  /// [query] and returns the best match, or `null` if nothing resolves to a
+  /// playable video.
   ///
   /// Goes through the same `WEB_REMIX` browse/search endpoints as
   /// [getArtistProfile] instead of the public search results page, which is
   /// what keeps this from tripping YouTube's anti-scraping rate limiting the
-  /// way scraping `youtube.com/results` repeatedly does.
+  /// way scraping `youtube.com/results` repeatedly does. Filtering to the
+  /// Songs shelf specifically (rather than the general mixed search) also
+  /// keeps videos/albums/artists sharing the query from crowding out the
+  /// actual song candidates.
   ///
-  /// Unlike an artist page's "Top songs" shelf, a search result row's second
-  /// column is a single `Song • Artist • Album` (or `Video • Channel •
-  /// Views`) line rather than a bare artist name, so it has to be split on
-  /// the bullet separator first.
+  /// Every row in this shelf is already a song, so unlike a general search
+  /// result its subtitle is `Artist • Album • Duration`, with no leading
+  /// type label to skip.
   ///
   /// [expectedArtist] and [expectedTitle], when given, reject any row whose
-  /// credited artist or title doesn't loosely match them (see
-  /// [_looselyMatch]) instead of trusting YouTube Music's top result
-  /// blindly. This matters for callers matching a known (title, artist)
-  /// pair — e.g. a Spotify CSV import — where a viral cover/remix of a
-  /// common title can otherwise rank above the original (wrong artist,
-  /// matching title), and checking the artist alone isn't enough either:
-  /// the next-best same-artist result can just as easily be a completely
-  /// different song by them (matching artist, wrong title). Both checks
-  /// together bring the risk down to "no result" rather than either kind of
-  /// wrong one.
+  /// credited artist or title doesn't match them closely enough (see
+  /// [_looselyMatch] and [_titleMatches]) instead of trusting YouTube
+  /// Music's top result blindly. This matters for callers matching a known
+  /// (title, artist) pair — e.g. a Spotify CSV import — where a viral
+  /// cover/remix of a common title can otherwise rank above the original
+  /// (wrong artist, matching title), checking the artist alone isn't enough
+  /// either since the next-best same-artist result can just as easily be a
+  /// different song by them (matching artist, wrong title), and even a
+  /// title that matches by substring can still be a live/remix/cover
+  /// recording rather than the original. All three checks together bring
+  /// the risk down to "no result" rather than any of those wrong ones.
   Future<Video?> searchSong(
     String query, {
     String? expectedArtist,
@@ -244,11 +277,11 @@ class MusicClient {
     final root = await _httpClient.sendPost('search', {
       'context': _remixContext,
       'query': normalizedQuery,
+      'params': _songsSearchParams,
     }, validate: true);
 
     final isValidating = expectedArtist != null || expectedTitle != null;
     Video? fallback;
-    Video? bestMatch;
     for (final item in _findRenderers(
       root,
       'musicResponsiveListItemRenderer',
@@ -260,32 +293,25 @@ class MusicClient {
       if (title == null || title.isEmpty) continue;
 
       final subtitleParts = _splitBullets(_flexColumnText(item, 1));
-      final type = subtitleParts.isNotEmpty
-          ? subtitleParts.first.toLowerCase()
-          : '';
-      final artist = subtitleParts.length >= 2
-          ? subtitleParts[1]
-          : (subtitleParts.isNotEmpty ? subtitleParts.first : '');
+      final artist = subtitleParts.isNotEmpty ? subtitleParts.first : '';
 
       final video = _trackVideo(item, videoId, title, artist, null);
       fallback ??= video;
 
-      final artistOk =
-          expectedArtist == null || _looselyMatch(artist, expectedArtist);
-      final titleOk =
-          expectedTitle == null || _looselyMatch(title, expectedTitle);
-      if (!artistOk || !titleOk) continue;
+      if (expectedArtist != null && !_looselyMatch(artist, expectedArtist)) {
+        continue;
+      }
+      if (expectedTitle != null && !_titleMatches(title, expectedTitle)) {
+        continue;
+      }
 
-      // Prefer a canonical "Song" row over a "Video"/other row further down.
-      if (type == 'song') return video;
-      bestMatch ??= video;
+      return video;
     }
 
     // Without anything to validate, preserve the original behavior: fall
-    // back to the first result of any type. With validation requested, a
-    // mismatched top result is worse than no result, so don't fall back
-    // to it.
-    return bestMatch ?? (isValidating ? null : fallback);
+    // back to the first result. With validation requested, a mismatched
+    // top result is worse than no result, so don't fall back to it.
+    return isValidating ? null : fallback;
   }
 
   /// Splits a `Song • Artist • Album` style subtitle line on its bullet
@@ -311,6 +337,24 @@ class MusicClient {
     final b = _normalizeForMatch(expected);
     if (a.isEmpty || b.isEmpty) return true;
     return a.contains(b) || b.contains(a);
+  }
+
+  /// Like [_looselyMatch], but additionally rejects a candidate title that
+  /// carries an [_alternateVersionKeywords] word the expected title doesn't
+  /// — e.g. expected "Mother" doesn't accept candidate "Mother (Live 1989)"
+  /// just because "mother" is a substring of it.
+  bool _titleMatches(String candidate, String expected) {
+    if (!_looselyMatch(candidate, expected)) return false;
+
+    final candidateWords = _normalizeForMatch(candidate).split(' ').toSet();
+    final expectedWords = _normalizeForMatch(expected).split(' ').toSet();
+    for (final keyword in _alternateVersionKeywords) {
+      if (candidateWords.contains(keyword) &&
+          !expectedWords.contains(keyword)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   String _normalizeForMatch(String input) => input

--- a/packages/youtube_music_explode_dart/lib/src/music_client.dart
+++ b/packages/youtube_music_explode_dart/lib/src/music_client.dart
@@ -221,7 +221,23 @@ class MusicClient {
   /// column is a single `Song • Artist • Album` (or `Video • Channel •
   /// Views`) line rather than a bare artist name, so it has to be split on
   /// the bullet separator first.
-  Future<Video?> searchSong(String query) async {
+  ///
+  /// [expectedArtist] and [expectedTitle], when given, reject any row whose
+  /// credited artist or title doesn't loosely match them (see
+  /// [_looselyMatch]) instead of trusting YouTube Music's top result
+  /// blindly. This matters for callers matching a known (title, artist)
+  /// pair — e.g. a Spotify CSV import — where a viral cover/remix of a
+  /// common title can otherwise rank above the original (wrong artist,
+  /// matching title), and checking the artist alone isn't enough either:
+  /// the next-best same-artist result can just as easily be a completely
+  /// different song by them (matching artist, wrong title). Both checks
+  /// together bring the risk down to "no result" rather than either kind of
+  /// wrong one.
+  Future<Video?> searchSong(
+    String query, {
+    String? expectedArtist,
+    String? expectedTitle,
+  }) async {
     final normalizedQuery = query.trim();
     if (normalizedQuery.isEmpty) return null;
 
@@ -230,7 +246,9 @@ class MusicClient {
       'query': normalizedQuery,
     }, validate: true);
 
+    final isValidating = expectedArtist != null || expectedTitle != null;
     Video? fallback;
+    Video? bestMatch;
     for (final item in _findRenderers(
       root,
       'musicResponsiveListItemRenderer',
@@ -250,11 +268,24 @@ class MusicClient {
           : (subtitleParts.isNotEmpty ? subtitleParts.first : '');
 
       final video = _trackVideo(item, videoId, title, artist, null);
+      fallback ??= video;
+
+      final artistOk =
+          expectedArtist == null || _looselyMatch(artist, expectedArtist);
+      final titleOk =
+          expectedTitle == null || _looselyMatch(title, expectedTitle);
+      if (!artistOk || !titleOk) continue;
+
       // Prefer a canonical "Song" row over a "Video"/other row further down.
       if (type == 'song') return video;
-      fallback ??= video;
+      bestMatch ??= video;
     }
-    return fallback;
+
+    // Without anything to validate, preserve the original behavior: fall
+    // back to the first result of any type. With validation requested, a
+    // mismatched top result is worse than no result, so don't fall back
+    // to it.
+    return bestMatch ?? (isValidating ? null : fallback);
   }
 
   /// Splits a `Song • Artist • Album` style subtitle line on its bullet
@@ -267,6 +298,26 @@ class MusicClient {
         .where((part) => part.isNotEmpty)
         .toList();
   }
+
+  /// Loose match used to reject a search row whose title or credited artist
+  /// clearly isn't the one being searched for. Both sides are compared by
+  /// substring containment after stripping punctuation, so e.g. "Arctic
+  /// Monkeys" matches "Arctic Monkeys", and "Sia" matches a row crediting
+  /// the multi-artist string "Sia & Diplo". An empty/unparseable side
+  /// doesn't block a match, since that just means the row didn't carry a
+  /// usable string to check in the first place.
+  bool _looselyMatch(String candidate, String expected) {
+    final a = _normalizeForMatch(candidate);
+    final b = _normalizeForMatch(expected);
+    if (a.isEmpty || b.isEmpty) return true;
+    return a.contains(b) || b.contains(a);
+  }
+
+  String _normalizeForMatch(String input) => input
+      .toLowerCase()
+      .replaceAll(RegExp(r'[^\w\s]'), ' ')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim();
 
   /// Returns a YouTube Music artist page: header details, top songs, the full
   /// discography and the artists it points to.


### PR DESCRIPTION
## Summary

Follow-up to #919 after several days of real-world use of the Spotify CSV import against large, varied playlists (300+ tracks, multiple languages including Portuguese and Cyrillic artist names). The search was still landing on the wrong recording surprisingly often, and importing a few hundred tracks took several minutes.

- **Wrong matches, fixed at the source.** `searchSong()` queried YouTube Music's general mixed search (songs, videos, albums, artists all competing for the same result slots), which could rank a live recording, a remix, or an unrelated track above the actual song — e.g. `Bad` by Michael Jackson matched a `Bad (Live)` upload from a different channel, and `I Wanna Be Yours` by Arctic Monkeys matched a cover. Filtering to YouTube Music's own dedicated "Songs" shelf (same param encoding already used for the artist-only filter in this file) removes that cross-category noise.
- **Title/artist validation.** `searchSong()` now takes `expectedArtist`/`expectedTitle` and rejects a candidate that doesn't match both, instead of trusting the top result blindly. Comparison is by *word set* rather than ordered text — is the shorter side's set of normalized words fully contained in the longer side's — so it isn't thrown off by word order, connector words ("&"/"and"/"e"), or a CSV's comma-joined multi-artist field vs. YouTube Music's own connector-joined credit for the same artists, without hand-coding per-language cases.
- **Unicode fix.** Dart's `\w` is ASCII-only. The first version of the word-set comparison reduced Cyrillic/CJK text to an empty set on both sides, which silently disabled validation for those catalogs (an empty side is treated as "no info to check"), and reduced accented Latin text to fragments that could false-positive. Switched to `\p{L}`/`\p{N}` (Unicode-aware) and added a diacritic fold so accented CSV text matches YouTube Music's accented listing and vice versa.
- **Faster import.** The 2-per-batch/400ms pacing was sized for the old scraped search this import used to go through, which really did need throttling. A ramp probe against the Songs-shelf endpoint (500 requests, up to 24 concurrent) never hit a rate limit, so the batch size went up substantially — a 300+ track import now takes well under a minute instead of several.
- **Retry pass.** A song landing in the "not found" list is sometimes just a transient dip in search quality rather than a real absence. The import now does one more pass over whatever's left unresolved once the main run finishes, unless YouTube is actively rate-limiting the device. Rows carry their original CSV position through both passes so a song recovered on retry lands back at its correct spot in the imported playlist instead of at the end.

A small fraction of tracks still won't resolve — mostly deep cuts or niche mashups/edits that genuinely don't have a dedicated "Song" entry on YouTube Music for that title+artist combination. These are still surfaced via the existing "missing songs" list (copied to clipboard) rather than silently dropped or force-matched to something wrong.

## Test plan

- [x] `flutter analyze` clean, no new warnings
- [x] Verified against two real, unrelated CSV playlists (333 tracks in English, 131 tracks mostly Portuguese with heavy multi-artist funk/sertanejo credits) — before/after match-quality comparison
- [x] Manually verified Cyrillic (Кино), CJK, and accented Latin (Portuguese) title/artist matching, plus a targeted false-positive check ("MØ" no longer matches "M.I.A.")
- [x] On-device testing (Android) of the full import flow, including the retry pass and playlist ordering