### PR TITLE
Collapsing header title on liked/offline/recents and folder pages

### DIFF
--- a/lib/screens/playlist_folder_page.dart
+++ b/lib/screens/playlist_folder_page.dart
@@ -73,9 +73,25 @@ class _PlaylistFolderPageState extends State<PlaylistFolderPage> {
             slivers: [
               SliverAppBar(
                 pinned: true,
-                expandedHeight: 300,
+                expandedHeight: 320,
                 flexibleSpace: FlexibleSpaceBar(
-                  collapseMode: CollapseMode.pin,
+                  centerTitle: true,
+                  expandedTitleScale: 1.35,
+                  titlePadding: const EdgeInsetsDirectional.only(
+                    start: 64,
+                    end: 64,
+                    bottom: 16,
+                  ),
+                  title: Text(
+                    _folderName,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: Theme.of(context).colorScheme.onSurface,
+                      letterSpacing: 0,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
                   background: _buildHeader(context, playlists.length),
                 ),
                 actions: [
@@ -164,7 +180,9 @@ class _PlaylistFolderPageState extends State<PlaylistFolderPage> {
     final theme = Theme.of(context);
     return Container(
       alignment: Alignment.center,
-      padding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
+      // Extra bottom room for the folder name, which slides up into the app bar
+      // from the FlexibleSpaceBar title as the header collapses.
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 56),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -189,18 +207,6 @@ class _PlaylistFolderPageState extends State<PlaylistFolderPage> {
             ),
           ),
           const SizedBox(height: 20),
-          Text(
-            _folderName,
-            style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.w700,
-              color: colorScheme.onSurface,
-              letterSpacing: -0.3,
-            ),
-            overflow: TextOverflow.ellipsis,
-            maxLines: 2,
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 10),
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 7),
             decoration: BoxDecoration(

--- a/lib/screens/user_songs_page.dart
+++ b/lib/screens/user_songs_page.dart
@@ -86,7 +86,6 @@ class _UserSongsPageState extends State<UserSongsPage> {
     final isOfflineSongs = title == context.l10n!.offlineSongs;
 
     return Scaffold(
-      appBar: AppBar(title: offlineMode.value ? Text(title) : null),
       body: Padding(
         padding: commonSingleChildScrollViewPadding,
         child: ValueListenableBuilder(
@@ -121,12 +120,57 @@ class _UserSongsPageState extends State<UserSongsPage> {
   ) {
     return CustomScrollView(
       slivers: [
+        SliverAppBar(
+          pinned: true,
+          expandedHeight:
+              MediaQuery.sizeOf(context).width >
+                  MediaQuery.sizeOf(context).height
+              ? 380
+              : 320,
+          flexibleSpace: FlexibleSpaceBar(
+            centerTitle: true,
+            expandedTitleScale: 1.35,
+            titlePadding: const EdgeInsetsDirectional.only(
+              start: 64,
+              end: 64,
+              bottom: 16,
+            ),
+            title: Text(
+              title,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: Theme.of(context).colorScheme.onSurface,
+                letterSpacing: 0,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            background: Padding(
+              padding: const EdgeInsets.only(top: 56, bottom: 64),
+              child: Center(child: _buildHeroArtwork(title, icon)),
+            ),
+          ),
+        ),
         SliverToBoxAdapter(
           child: _buildHeaderSection(title, icon, songsLength, isOfflineSongs),
         ),
         buildSongList(title),
         const SliverMiniPlayerBottomSpace(),
       ],
+    );
+  }
+
+  Widget _buildHeroArtwork(String title, IconData icon) {
+    return ClipPath(
+      clipper: const ShapeBorderClipper(
+        shape: StarBorder(
+          points: 8,
+          pointRounding: 0.8,
+          valleyRounding: 0.2,
+          innerRadiusRatio: 0.6,
+        ),
+      ),
+      child: _buildPlaylistImage(title, icon),
     );
   }
 
@@ -163,6 +207,8 @@ class _UserSongsPageState extends State<UserSongsPage> {
           _buildPlaylistImage(title, icon),
           title,
           songsLength: songsLength,
+          showImage: false,
+          showTitle: false,
         ),
         if (songsLength > 0) ...[
           Padding(


### PR DESCRIPTION
## What

The playlist / album / artist pages animate their title up into a pinned app bar as the header scrolls away (added in *"polish playlist app bar"*). The **liked songs**, **offline songs**, **recently played** and **playlist‑folder** pages were left with a plain static header, so the same interaction was missing there.

This gives those four pages the same collapsing `SliverAppBar` + `FlexibleSpaceBar` title.

## Changes

- **`user_songs_page.dart`** (liked / offline / recents): drop the static `AppBar`, add a `SliverAppBar` whose flexible space holds the artwork as background and the page name as the collapsing title. The in‑body `PlaylistHeader` now renders only the chips and action buttons (`showImage: false`, `showTitle: false`).
- **`playlist_folder_page.dart`** (folders): it already had a `SliverAppBar`, so the folder name just moves out of the background column into the `FlexibleSpaceBar` title; extra bottom padding keeps it clear of the count chip while it slides up.

## Testing

- `flutter analyze` clean.
- Ran on device: on *Liked songs* the title collapses from under the artwork into the pinned bar exactly like the playlist page; back button still shown when the page is pushed and hidden when *Offline songs* is the offline‑mode root.