### PR TITLE
Stop playlist sorting from corrupting the saved order baseline

### DIFF
--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -155,7 +155,7 @@ class _PlaylistPageState extends State<PlaylistPage> {
       }
 
       if (_playlist != null && _playlist['list'] != null) {
-        _originalPlaylistList = List<dynamic>.from(_playlist['list'] as List);
+        _adoptPlaylist(_playlist);
         _sortPlaylist(_sortType);
       }
     } catch (e, stackTrace) {
@@ -517,10 +517,7 @@ class _PlaylistPageState extends State<PlaylistPage> {
           unawaited(syncOfflinePlaylistMetadata(updatedPlaylist));
 
           setState(() {
-            _playlist = updatedPlaylist;
-            _originalPlaylistList = List<dynamic>.from(
-              updatedPlaylist['list'] as List? ?? const [],
-            );
+            _adoptPlaylist(updatedPlaylist);
             _sortPlaylist(_sortType);
           });
           showToast(context, context.l10n!.playlistUpdated);
@@ -577,10 +574,7 @@ class _PlaylistPageState extends State<PlaylistPage> {
     }
     if (updated != null && mounted) {
       setState(() {
-        _playlist = updated;
-        _originalPlaylistList = List<dynamic>.from(
-          _playlist['list'] as List? ?? const [],
-        );
+        _adoptPlaylist(updated);
         _sortPlaylist(_sortType);
       });
       if (isCachedPage) {
@@ -637,6 +631,25 @@ class _PlaylistPageState extends State<PlaylistPage> {
       case PlaylistSortType.dateAdded:
         return context.l10n!.dateAdded;
     }
+  }
+
+  /// Take a page-owned copy of [source] and snapshot its untouched order.
+  ///
+  /// `getPlaylistInfoForWidget` hands back the very map instances kept in the
+  /// playlist caches. `_sortPlaylist` rewrites `_playlist['list']`, so without a
+  /// copy a sort leaks back into the cache: reopening the page then read the
+  /// already-reordered list as the "original", and `default_`/`dateAdded`
+  /// (which are defined relative to that snapshot) showed the wrong order while
+  /// the saved sort chip still looked selected.
+  void _adoptPlaylist(dynamic source) {
+    if (source is! Map) {
+      _playlist = source;
+      _originalPlaylistList = <dynamic>[];
+      return;
+    }
+    _playlist = Map<String, dynamic>.from(source);
+    final list = source['list'];
+    _originalPlaylistList = list is List ? List<dynamic>.from(list) : <dynamic>[];
   }
 
   void _sortPlaylist(PlaylistSortType type) {


### PR DESCRIPTION
## Bug

On a playlist page, pick **Date added** (or **Default**), leave the page and re‑open it: the sort chip is still shown as selected, but the list is in the *other* order — and tapping the chip that looks unselected swaps them back. Every back‑and‑forth flips the order again. **Name / Artist** are unaffected.

## Cause

`getPlaylistInfoForWidget` (and the custom / offline / artist lookups it delegates to) return the **same `Map` instances** that live in the in‑memory playlist caches. `_sortPlaylist` rewrites `_playlist['list']` in place, so the sort leaks straight back into the cache.

On the next open the page captures that already‑reordered list as `_originalPlaylistList`. `default_` and `dateAdded` are defined *relative to that snapshot* (`dateAdded` = `_originalPlaylistList.reversed`), so re‑sorting undoes the previous sort: the list shows the wrong order while the persisted chip still looks selected. `title` / `artist` are absolute sorts, so they always self‑correct — which is why only Default/Date added were visibly broken.

## Fix

Add `_adoptPlaylist()` — it takes a page‑owned copy of the playlist map and its list before any sort runs, at the three points where `_playlist` is (re)assigned from an external source: initial load, after an edit, and after a sync. The caches are never mutated again, so the "original order" baseline stays correct across reopens.

## Testing

- `flutter analyze` clean.
- On device: open a custom playlist, Date added, back, re‑open → chip **and** list now agree (reversed); toggling Default/Date added stays consistent on every reopen. Verified the same for an offline playlist and an artist page. Name/Artist unchanged.