### PR TITLE
fix(audio): keep media notification duration accurate

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -33,6 +33,7 @@ import 'package:musify/services/data_manager.dart';
 import 'package:musify/services/listening_stats_service.dart';
 import 'package:musify/services/settings_manager.dart';
 import 'package:musify/utilities/map_utils.dart';
+import 'package:musify/utilities/media_duration.dart';
 import 'package:musify/utilities/mediaitem.dart';
 import 'package:musify/utilities/queue_entry_utils.dart';
 import 'package:rxdart/rxdart.dart';
@@ -86,6 +87,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
   int _currentLoadingTransitionId = -1;
   bool _isUpdatingState = false;
   bool _pendingPlaybackStateUpdate = false;
+  bool _pendingForcedPlaybackStateUpdate = false;
   int _songTransitionCounter = 0;
 
   bool _completionEventPending = false;
@@ -194,8 +196,13 @@ class MusifyAudioHandler extends BaseAudioHandler {
 
     audioPlayer.durationStream.listen(
       (duration) {
-        if (_currentQueueIndex < _queueList.length && duration != null) {
-          _updateCurrentMediaItemWithDuration(duration);
+        if (_currentQueueIndex < _queueList.length &&
+            duration != null &&
+            _playerSourceMatchesCurrentSong()) {
+          _updateCurrentMediaItemWithDuration(
+            duration,
+            preserveLongerKnown: _currentPlayerSourceIsClipped(),
+          );
         }
       },
       onError: (error, stackTrace) {
@@ -260,6 +267,36 @@ class MusifyAudioHandler extends BaseAudioHandler {
   List<MediaItem> _buildQueueMediaItems() =>
       _queueList.map(_getMediaItemForQueue).toList(growable: false);
 
+  bool _playerSourceMatchesCurrentSong() {
+    if (_currentQueueIndex < 0 || _currentQueueIndex >= _queueList.length) {
+      return false;
+    }
+
+    final sourceTag = audioPlayer.sequenceState.currentSource?.tag;
+    if (sourceTag is! MediaItem) return false;
+
+    final sourceYtid = sourceTag.extras?['ytid']?.toString();
+    final currentYtid = _queueList[_currentQueueIndex]['ytid']?.toString();
+    if (sourceYtid != null &&
+        sourceYtid.isNotEmpty &&
+        currentYtid != null &&
+        currentYtid.isNotEmpty) {
+      return sourceYtid == currentYtid;
+    }
+
+    final currentId = _queueList[_currentQueueIndex]['id']?.toString();
+    return currentId != null &&
+        currentId.isNotEmpty &&
+        sourceTag.id == currentId;
+  }
+
+  bool _currentPlayerSourceIsClipped() {
+    // A clipped SponsorBlock child can report only its own duration. Keeping
+    // the longer track metadata deliberately favors a stable full-track total
+    // over briefly publishing a segment length in the system notification.
+    return audioPlayer.sequenceState.currentSource is ClippingAudioSource;
+  }
+
   bool _shouldUpdateDuration(Duration? currentDuration, Duration nextDuration) {
     return currentDuration == null ||
         !durationEquals(currentDuration, nextDuration);
@@ -281,7 +318,10 @@ class MusifyAudioHandler extends BaseAudioHandler {
         currentItem.extras?['ytid']?.toString() == currentSongYtid;
   }
 
-  void _updateCurrentMediaItemWithDuration(Duration duration) {
+  void _updateCurrentMediaItemWithDuration(
+    Duration duration, {
+    bool preserveLongerKnown = false,
+  }) {
     try {
       final queueIndex = _currentQueueIndex;
       if (queueIndex < 0 || queueIndex >= _queueList.length) return;
@@ -296,26 +336,82 @@ class MusifyAudioHandler extends BaseAudioHandler {
         currentSongYtid,
       );
 
+      final existingQueue = queue.valueOrNull;
+      final queueItem =
+          existingQueue != null && queueIndex < existingQueue.length
+          ? existingQueue[queueIndex]
+          : null;
+      final storedDuration = readMediaDuration(currentSong['duration']);
+      var stableDuration = storedDuration;
+      if (isMatchingCurrentItem) {
+        stableDuration = preferStableMediaDuration(
+          stableDuration,
+          currentItem?.duration,
+          preserveLongerKnown: true,
+        );
+      }
+      stableDuration = preferStableMediaDuration(
+        stableDuration,
+        queueItem?.duration,
+        preserveLongerKnown: true,
+      );
+      stableDuration = preferStableMediaDuration(
+        stableDuration,
+        duration,
+        preserveLongerKnown: preserveLongerKnown,
+      );
+      if (stableDuration == null) return;
+
+      final durationSeconds = stableDuration.inSeconds;
+      var queueMapChanged = false;
+      if (_shouldUpdateDuration(storedDuration, stableDuration)) {
+        currentSong['duration'] = durationSeconds;
+        queueMapChanged = true;
+      }
+      final queueEntryId = _queueEntryIds.ensureId(currentSong);
+      for (final originalSong in _originalQueueList) {
+        if (_queueEntryIds.ensureId(originalSong) == queueEntryId) {
+          if (_shouldUpdateDuration(
+            readMediaDuration(originalSong['duration']),
+            stableDuration,
+          )) {
+            originalSong['duration'] = durationSeconds;
+          }
+          break;
+        }
+      }
+
+      var mediaItemChanged = false;
       if (currentItem != null &&
           isMatchingCurrentItem &&
-          _shouldUpdateDuration(currentItem.duration, duration)) {
-        mediaItem.add(currentItem.copyWith(duration: duration));
+          _shouldUpdateDuration(currentItem.duration, stableDuration)) {
+        mediaItem.add(currentItem.copyWith(duration: stableDuration));
+        mediaItemChanged = true;
       } else if (!isMatchingCurrentItem) {
-        mediaItem.add(currentMediaItem.copyWith(duration: duration));
+        mediaItem.add(currentMediaItem.copyWith(duration: stableDuration));
+        mediaItemChanged = true;
       }
 
       listeningStatsService.updateListeningSessionDuration(
         currentSongYtid,
-        duration,
+        stableDuration,
       );
 
-      final existingQueue = queue.valueOrNull;
       if (existingQueue != null && queueIndex < existingQueue.length) {
-        final queueItem = existingQueue[queueIndex];
-        if (_shouldUpdateDuration(queueItem.duration, duration)) {
+        var publishedQueueChanged = false;
+        if (_shouldUpdateDuration(queueItem?.duration, stableDuration)) {
           final updatedQueue = List<MediaItem>.from(existingQueue);
-          updatedQueue[queueIndex] = queueItem.copyWith(duration: duration);
+          updatedQueue[queueIndex] = queueItem!.copyWith(
+            duration: stableDuration,
+          );
           queue.add(updatedQueue);
+          publishedQueueChanged = true;
+        }
+        if (queueMapChanged) {
+          _queueMapStream.add(List.unmodifiable(_queueList));
+        }
+        if (mediaItemChanged || publishedQueueChanged) {
+          _updatePlaybackState(force: true);
         }
         return;
       }
@@ -323,10 +419,14 @@ class MusifyAudioHandler extends BaseAudioHandler {
       final rebuiltQueue = _buildQueueMediaItems();
       if (queueIndex < rebuiltQueue.length) {
         rebuiltQueue[queueIndex] = rebuiltQueue[queueIndex].copyWith(
-          duration: duration,
+          duration: stableDuration,
         );
       }
       queue.add(rebuiltQueue);
+      if (queueMapChanged) {
+        _queueMapStream.add(List.unmodifiable(_queueList));
+      }
+      _updatePlaybackState(force: true);
     } catch (e, stackTrace) {
       logger.log(
         'Error updating media item with duration',
@@ -531,9 +631,10 @@ class MusifyAudioHandler extends BaseAudioHandler {
         const Duration(milliseconds: 500);
   }
 
-  void _updatePlaybackState() {
+  void _updatePlaybackState({bool force = false}) {
     if (_isUpdatingState) {
       _pendingPlaybackStateUpdate = true;
+      _pendingForcedPlaybackStateUpdate |= force;
       return;
     }
 
@@ -574,7 +675,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
             currentState.speed,
           ));
 
-      if (shouldUpdate) {
+      if (force || shouldUpdate) {
         playbackState.add(
           PlaybackState(
             controls: _controls(isPlaying),
@@ -607,8 +708,10 @@ class MusifyAudioHandler extends BaseAudioHandler {
     } finally {
       _isUpdatingState = false;
       if (_pendingPlaybackStateUpdate) {
+        final forcePendingUpdate = _pendingForcedPlaybackStateUpdate;
         _pendingPlaybackStateUpdate = false;
-        _updatePlaybackState();
+        _pendingForcedPlaybackStateUpdate = false;
+        _updatePlaybackState(force: forcePendingUpdate);
       }
     }
   }
@@ -2004,7 +2107,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
       // source, not whatever session we're about to finish.
       final wasPlayingBeforeSwap = audioPlayer.playing;
 
-      await audioPlayer
+      final loadedDuration = await audioPlayer
           .setAudioSource(audioSource)
           .timeout(_songTransitionTimeout);
 
@@ -2016,8 +2119,12 @@ class MusifyAudioHandler extends BaseAudioHandler {
         return false;
       }
 
-      if (audioPlayer.duration != null) {
-        _updateCurrentMediaItemWithDuration(audioPlayer.duration!);
+      final resolvedDuration = loadedDuration ?? audioPlayer.duration;
+      if (resolvedDuration != null && _playerSourceMatchesCurrentSong()) {
+        _updateCurrentMediaItemWithDuration(
+          resolvedDuration,
+          preserveLongerKnown: _currentPlayerSourceIsClipped(),
+        );
       }
 
       // Finish the old session and start the new one as one atomic pair, only
@@ -2335,6 +2442,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
             child: source,
             start: Duration(seconds: lastEnd),
             end: Duration(seconds: start),
+            tag: source.tag,
           ),
         );
       }
@@ -2344,6 +2452,7 @@ class MusifyAudioHandler extends BaseAudioHandler {
       ClippingAudioSource(
         child: source,
         start: Duration(seconds: lastEnd),
+        tag: source.tag,
       ),
     );
     if (children.length == 1) return children.first;

--- a/lib/utilities/media_duration.dart
+++ b/lib/utilities/media_duration.dart
@@ -1,0 +1,78 @@
+/*
+ *     Copyright (C) 2026 Valeri Gokadze
+ *
+ *     Musify is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     Musify is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ *     For more information about Musify, including how to contribute,
+ *     please visit: https://github.com/gokadzev/Musify
+ */
+
+/// Converts the duration formats used by song maps into a positive duration.
+///
+/// A zero duration is treated as unknown. Publishing zero to Android's media
+/// session makes the system player render a misleading `00:00` total.
+Duration? readMediaDuration(dynamic value) {
+  Duration? duration;
+
+  if (value is Duration) {
+    duration = value;
+  } else if (value is num) {
+    if (!value.isFinite) return null;
+    duration = Duration(milliseconds: (value * 1000).round());
+  } else {
+    final text = value?.toString().trim();
+    if (text == null || text.isEmpty) return null;
+
+    final numericSeconds = double.tryParse(text);
+    if (numericSeconds != null && numericSeconds.isFinite) {
+      duration = Duration(milliseconds: (numericSeconds * 1000).round());
+    } else {
+      final parts = text.split(':').map(int.tryParse).toList();
+      if (parts.any((part) => part == null)) return null;
+      if (parts.length == 2) {
+        duration = Duration(minutes: parts[0]!, seconds: parts[1]!);
+      } else if (parts.length == 3) {
+        duration = Duration(
+          hours: parts[0]!,
+          minutes: parts[1]!,
+          seconds: parts[2]!,
+        );
+      }
+    }
+  }
+
+  return duration != null && duration > Duration.zero ? duration : null;
+}
+
+/// Chooses a reported player duration while keeping an unknown report from
+/// replacing a valid value.
+///
+/// A clipped source can temporarily report the duration of only its current
+/// segment. Callers that know the report came from such a source may preserve
+/// the longer known total until the complete source duration is available.
+Duration? preferStableMediaDuration(
+  Duration? known,
+  Duration? reported, {
+  bool preserveLongerKnown = false,
+}) {
+  final validKnown = readMediaDuration(known);
+  final validReported = readMediaDuration(reported);
+
+  if (validReported == null) return validKnown;
+  if (preserveLongerKnown && validKnown != null && validReported < validKnown) {
+    return validKnown;
+  }
+  return validReported;
+}

--- a/lib/utilities/mediaitem.dart
+++ b/lib/utilities/mediaitem.dart
@@ -21,6 +21,7 @@
 
 import 'package:audio_service/audio_service.dart';
 import 'package:musify/services/common_services.dart';
+import 'package:musify/utilities/media_duration.dart';
 
 Map mediaItemToMap(MediaItem mediaItem) {
   final extras = mediaItem.extras;
@@ -35,6 +36,7 @@ Map mediaItemToMap(MediaItem mediaItem) {
     'highResImage': extras?['highResImage'] ?? mediaItem.artUri.toString(),
     'lowResImage': extras?['lowResImage'],
     'isLive': extras?['isLive'] ?? false,
+    if (mediaItem.duration case final duration?) 'duration': duration.inSeconds,
   };
 }
 
@@ -54,9 +56,7 @@ MediaItem mapToMediaItem(Map song) {
     artist: song['artist'].toString().trim(),
     title: song['title'].toString(),
     artUri: artUri,
-    duration: song['duration'] != null
-        ? Duration(seconds: song['duration'])
-        : null,
+    duration: readMediaDuration(song['duration']),
     extras: {
       'lowResImage': song['lowResImage'],
       'ytid': song['ytid'],

--- a/test/media_duration_test.dart
+++ b/test/media_duration_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:musify/utilities/media_duration.dart';
+
+void main() {
+  group('readMediaDuration', () {
+    test('accepts the duration formats stored in song maps', () {
+      expect(readMediaDuration(185), const Duration(seconds: 185));
+      expect(readMediaDuration(185.5), const Duration(milliseconds: 185500));
+      expect(readMediaDuration('185'), const Duration(seconds: 185));
+      expect(
+        readMediaDuration('03:05'),
+        const Duration(minutes: 3, seconds: 5),
+      );
+      expect(
+        readMediaDuration('01:03:05'),
+        const Duration(hours: 1, minutes: 3, seconds: 5),
+      );
+    });
+
+    test('treats zero, negative, and malformed values as unknown', () {
+      expect(readMediaDuration(null), isNull);
+      expect(readMediaDuration(0), isNull);
+      expect(readMediaDuration(-1), isNull);
+      expect(readMediaDuration(double.infinity), isNull);
+      expect(readMediaDuration('00:00'), isNull);
+      expect(readMediaDuration('unknown'), isNull);
+    });
+  });
+
+  group('preferStableMediaDuration', () {
+    test('does not replace a known duration with an invalid report', () {
+      const known = Duration(minutes: 3);
+
+      expect(preferStableMediaDuration(known, Duration.zero), known);
+    });
+
+    test('accepts an initial or corrected player duration', () {
+      const reported = Duration(minutes: 3);
+
+      expect(preferStableMediaDuration(null, reported), reported);
+      expect(
+        preferStableMediaDuration(const Duration(minutes: 4), reported),
+        reported,
+      );
+    });
+
+    test('preserves a known total for clipped segment reports', () {
+      const known = Duration(minutes: 3);
+      const segment = Duration(seconds: 40);
+
+      expect(
+        preferStableMediaDuration(known, segment, preserveLongerKnown: true),
+        known,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- parse and publish valid media durations instead of exposing unknown values as `00:00`
- update the active media item and queue when the player resolves the real duration
- reject stale duration events from a previous track during transitions
- preserve the known full-track duration when SponsorBlock clipping reports only a child segment
- avoid redundant queue and playback-state publications when the duration has not changed

## Testing

- `flutter analyze lib/services/audio_service.dart lib/utilities/media_duration.dart lib/utilities/mediaitem.dart test/media_duration_test.dart`
- `flutter test test/media_duration_test.dart`
- `flutter run --flavor github` on a Xiaomi device running Android 16
- verified non-zero duration on initial playback and after switching tracks from the system media notification