### PR TITLE
fix: stop listening recap covers from swapping between songs

### DIFF
--- a/lib/widgets/listening_recap_card.dart
+++ b/lib/widgets/listening_recap_card.dart
@@ -101,6 +101,10 @@ class ListeningRecapCard extends StatelessWidget {
             if (songs.isNotEmpty) ...[
               for (var i = 0; i < songs.length; i++)
                 SongBar(
+                  // Key by song identity so a reordered recap list rebinds each
+                  // row to its own song instead of reusing the previous
+                  // occupant's cached artwork.
+                  key: ValueKey(songs[i]['ytid'] ?? i),
                   songs[i],
                   false,
                   showPlayTime: true,


### PR DESCRIPTION
## Problem

On the home screen, the **Time Machine / listening recap** card sometimes shows a song with the **wrong cover** — the artwork of another song that is also in the recap list. It surfaces after listening activity changes the ranking of the current month's top songs.

## Cause

`ListeningRecapCard` renders each `SongBar` in a keyless `for` loop. `_buildCurrentMonthRecapSection` calls `listeningStatsService.monthTopSongs(...)` on every home rebuild, and that returns a freshly **re-ranked** list. With no keys, Flutter re-associates the existing `SongBar` elements with whatever song now sits at each position.

`_SongBarState` caches `_artworkPath` / `_lowResImageUrl` / `_ytid` in `initState` and only re-syncs the title/artist in `didUpdateWidget`. So a reused row updates its text to the new song but keeps the **previous song's cached artwork**.

This is the same class of bug that was fixed for song search inside a playlist.

## Fix

Key each row by song identity (`ValueKey(song['ytid'] ?? i)`) so a reordered recap list rebinds every row to its own song, giving it a fresh state with the correct artwork. No behavior change when the list is stable.

Minimal diff, no listeners. `flutter analyze` clean.