### PR TITLE
fix: match radio station card background to the rest of the app

### DIFF
--- a/lib/widgets/radio_station_card.dart
+++ b/lib/widgets/radio_station_card.dart
@@ -90,7 +90,7 @@ class _RadioStationCardState extends State<RadioStationCard> {
 
     return Card(
       elevation: 0,
-      color: colorScheme.surfaceContainer,
+      color: colorScheme.surfaceContainerLow,
       clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       margin: EdgeInsets.zero,


### PR DESCRIPTION
## Problem

On the radio stations page (and radio results in search), `RadioStationCard` renders on `colorScheme.surfaceContainer`, one tonal step above every other list row in the app. `SongBar`, `PlaylistBar` and `CustomBar` all use `colorScheme.surfaceContainerLow`, so the radio cards look like a heavier, more opaque surface that doesn't blend with the rest of the UI.

## Fix

Use `colorScheme.surfaceContainerLow` for `RadioStationCard`, matching the shared list-row background.

One line. `flutter analyze` clean.