### PR TITLE
fix: let the radio stations list scroll under the mini player

### DIFF
--- a/lib/screens/radio_stations_page.dart
+++ b/lib/screens/radio_stations_page.dart
@@ -51,34 +51,38 @@ class RadioStationsPage extends StatelessWidget {
           return SingleChildScrollView(
             padding: commonSingleChildScrollViewPadding,
             child: Column(
-              children: List.generate(stations.length, (index) {
-                final station = stations[index];
-                return Padding(
-                  key: ValueKey(station.id),
-                  padding: const EdgeInsets.only(bottom: 8),
-                  child: RadioStationCard(
-                    station: station,
-                    onPressed: () async {
-                      final success = await audioHandler.playRadioStream(
-                        id: station.id,
-                        name: station.name,
-                        streamUrl: station.streamUrl,
-                        image: station.image,
-                        genre: station.genre,
-                      );
+              children: [
+                ...List.generate(stations.length, (index) {
+                  final station = stations[index];
+                  return Padding(
+                    key: ValueKey(station.id),
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: RadioStationCard(
+                      station: station,
+                      onPressed: () async {
+                        final success = await audioHandler.playRadioStream(
+                          id: station.id,
+                          name: station.name,
+                          streamUrl: station.streamUrl,
+                          image: station.image,
+                          genre: station.genre,
+                        );
 
-                      if (!success && context.mounted) {
-                        showToast(context, context.l10n!.error);
-                      }
-                    },
-                  ),
-                );
-              }),
+                        if (!success && context.mounted) {
+                          showToast(context, context.l10n!.error);
+                        }
+                      },
+                    ),
+                  );
+                }),
+                // Lets the list scroll under the floating mini player instead of
+                // ending in a blank strip above it.
+                const MiniPlayerBottomSpace(),
+              ],
             ),
           );
         },
       ),
-      bottomNavigationBar: const MiniPlayerBottomSpace(),
     );
   }
 }


### PR DESCRIPTION
## Problem

On the radio stations page, the floating mini player sits over a blank strip: the station list ends above it instead of scrolling continuously beneath it like on every other page. It reads as if the mini player has no background / is stuck to the page background.

## Cause

`RadioStationsPage` reserved room for the mini player by putting `MiniPlayerBottomSpace` in `Scaffold.bottomNavigationBar`. A `Scaffold` with a `bottomNavigationBar` removes the bottom padding from its `body`, so the `SingleChildScrollView` never got the ~92 px the shell injects for the floating mini player, and `MiniPlayerBottomSpace` (a zero-size `SizedBox` in a `SafeArea`) became an empty fixed strip at the bottom.

Pages like `about`, `settings` and `equalizer` instead put `MiniPlayerBottomSpace` as the last child of their scrolling column, so their content scrolls under the bar.

## Fix

Move `MiniPlayerBottomSpace` to the end of the scrolling `Column` and drop the `bottomNavigationBar`. The list now scrolls under the floating mini player, matching the rest of the app.

Verified on device (Android 16 / HyperOS): the blank strip is gone and the last stations scroll behind the mini player.