### PR TITLE
fix: keep a fixed media notification control layout

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -145,19 +145,15 @@ class MusifyAudioHandler extends BaseAudioHandler {
   Stream<PlaybackState> get playbackStateStream => _playbackStateStream;
 
   List<MediaControl> _controls(bool playing) {
-    final hasMultipleTracks = _queueList.length > 1;
-
+    // Keep a fixed control layout: swapping skipToPrevious/skipToNext for
+    // rewind/fastForward on single-track queues makes some system media UIs
+    // (e.g. HyperOS) mismap the action buttons against MediaControl.stop.
+    // skipToNext/skipToPrevious already no-op safely at the queue edges.
     return [
-      if (hasMultipleTracks)
-        MediaControl.skipToPrevious
-      else
-        MediaControl.rewind,
+      MediaControl.skipToPrevious,
       if (playing) MediaControl.pause else MediaControl.play,
       MediaControl.stop,
-      if (hasMultipleTracks)
-        MediaControl.skipToNext
-      else
-        MediaControl.fastForward,
+      MediaControl.skipToNext,
     ];
   }
 


### PR DESCRIPTION
## Problem

On a single-track queue, the media notification's action buttons get mismapped on some system media UIs (reproduced on HyperOS / Android 16): the "skip to next" button shows the stop ("X") icon and the "X" triggers skip.

## Cause

`_controls()` swapped `skipToPrevious` / `skipToNext` for `rewind` / `fastForward` whenever `_queueList.length <= 1`. That changes the shape of the control list between updates, and `rewind` / `fastForward` have no dedicated slot in some system media UIs, so they get laid out positionally against `MediaControl.stop` and the icons/actions end up crossed. The optimistic loading state and `prepareFromMediaId` already publish the `skipToPrevious / play-pause / stop / skipToNext` layout, so the list shape wasn't even consistent within the handler.

## Fix

Always publish `skipToPrevious / play-pause / stop / skipToNext`. `skipToNext` and `skipToPrevious` already no-op safely at the queue edges (and `skipToPrevious` falls back to the history list), so nothing breaks on a single-track queue. `fastForward()` / `rewind()` stay implemented for Android Auto / headset media buttons; they're just no longer forced into the notification.

Multi-track playback is unchanged.

## Testing

- `flutter analyze lib/services/audio_service.dart` — clean
- On device (Android 16 / HyperOS), single-track queue: `dumpsys notification` now shows `actions=3` → `[Previous] [Pause] [Next]`, no rewind/fast-forward, and the buttons render/behave correctly.