### PR TITLE
fix(lyrics): fetch lyrics only when the lyrics view is opened

### DIFF
--- a/lib/widgets/now_playing/now_playing_artwork.dart
+++ b/lib/widgets/now_playing/now_playing_artwork.dart
@@ -111,70 +111,95 @@ class NowPlayingArtwork extends StatelessWidget {
             ),
           ],
         ),
-        child: AsyncLoader<String?>(
-          future: getSongLyrics(metadata.artist, metadata.title),
-          emptyWidget: Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  FluentIcons.text_quote_24_regular,
-                  size: 48,
-                  color: colorScheme.onSecondaryContainer.withValues(
-                    alpha: 0.5,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  context.l10n!.lyricsNotAvailable,
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.w500,
-                    color: colorScheme.onSecondaryContainer,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
+        child: _LyricsView(metadata: metadata),
+      ),
+    );
+  }
+}
+
+/// Fetches and shows the current song's lyrics.
+///
+/// Kept as its own widget so the network fetch in [getSongLyrics] only fires
+/// when the flip card actually mounts this side: opening Now Playing and never
+/// flipping to the lyrics costs no request. Resolves a single time per song
+/// (whenever [metadata]'s artist/title changes), like [_AudioQualityBadge].
+class _LyricsView extends StatefulWidget {
+  const _LyricsView({required this.metadata});
+  final MediaItem metadata;
+
+  @override
+  State<_LyricsView> createState() => _LyricsViewState();
+}
+
+class _LyricsViewState extends State<_LyricsView> {
+  String? _resolvedKey;
+  late Future<String?> _lyricsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolveIfNeeded();
+  }
+
+  @override
+  void didUpdateWidget(_LyricsView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _resolveIfNeeded();
+  }
+
+  void _resolveIfNeeded() {
+    final key = '${widget.metadata.artist} - ${widget.metadata.title}';
+    if (key == _resolvedKey) return;
+    _resolvedKey = key;
+    _lyricsFuture = getSongLyrics(
+      widget.metadata.artist,
+      widget.metadata.title,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    Widget unavailable() => Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            FluentIcons.text_quote_24_regular,
+            size: 48,
+            color: colorScheme.onSecondaryContainer.withValues(alpha: 0.5),
           ),
-          errorBuilder: (ctx, error, stack) => Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  FluentIcons.text_quote_24_regular,
-                  size: 48,
-                  color: colorScheme.onSecondaryContainer.withValues(
-                    alpha: 0.5,
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  context.l10n!.lyricsNotAvailable,
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.w500,
-                    color: colorScheme.onSecondaryContainer,
-                  ),
-                  textAlign: TextAlign.center,
-                ),
-              ],
+          const SizedBox(height: 16),
+          Text(
+            context.l10n!.lyricsNotAvailable,
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w500,
+              color: colorScheme.onSecondaryContainer,
             ),
+            textAlign: TextAlign.center,
           ),
-          builder: (context, lyrics) => SingleChildScrollView(
-            padding: const EdgeInsets.all(24),
-            physics: const BouncingScrollPhysics(),
-            child: Text(
-              lyrics ?? context.l10n!.lyricsNotAvailable,
-              style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.w500,
-                color: colorScheme.onSecondaryContainer,
-                height: 1.6,
-              ),
-              textAlign: TextAlign.center,
-            ),
+        ],
+      ),
+    );
+
+    return AsyncLoader<String?>(
+      future: _lyricsFuture,
+      emptyWidget: unavailable(),
+      errorBuilder: (ctx, error, stack) => unavailable(),
+      builder: (context, lyrics) => SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        physics: const BouncingScrollPhysics(),
+        child: Text(
+          lyrics ?? context.l10n!.lyricsNotAvailable,
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.w500,
+            color: colorScheme.onSecondaryContainer,
+            height: 1.6,
           ),
+          textAlign: TextAlign.center,
         ),
       ),
     );


### PR DESCRIPTION
## Problem

Lyrics are fetched automatically whenever the Now Playing screen is built — once per song while that screen is open — even for users who never flip the card to read the lyrics.

`getSongLyrics()` is called directly as the `future:` argument inside `NowPlayingArtwork.build()`, so the HTTP requests (lyrics.ovh → paroles.net → lyricsmania.com, the last two being full-page HTML scrapes) fire on every build of that screen regardless of whether the flip card is ever turned to the lyrics side.

## Change

Move the fetch into a dedicated `_LyricsView` widget used as the flip card's `backWidget`. `FlipCard` only mounts that side when it is shown, so the request now happens only when the user actually opens the lyrics. It resolves once per song (keyed on artist/title), following the same pattern as the existing `_AudioQualityBadge` in the same file.

No change to lyrics content, the `lastFetchedLyrics` cache, or offline-mode behavior.

## Testing

Built and run on a physical device (Android 15), verified with temporary instrumented logging in `getSongLyrics()`:

| Action | Before | After |
| --- | --- | --- |
| Open Now Playing, don't flip | fetches lyrics (3-source) | no request |
| Flip to lyrics view | fetches | fetches, lyrics render correctly |
| Flip away and back, same song | cached | cached, no new request |
| Switch song, open lyrics | fetches | fetches for the new song |

Closes #937 — with the fetch fully on-demand, the app no longer makes lyrics calls "unless asked", so a dedicated toggle shouldn't be needed.