### PR TITLE
fix(ui): center the icon in the no-artwork placeholder badge

### DIFF
--- a/lib/widgets/no_artwork_cube.dart
+++ b/lib/widgets/no_artwork_cube.dart
@@ -61,6 +61,7 @@ class NullArtworkWidget extends StatelessWidget {
               Container(
                 width: badgeSize,
                 height: badgeSize,
+                alignment: Alignment.center,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
                   color: colorScheme.primaryContainer.withValues(alpha: 0.55),


### PR DESCRIPTION
## What
`NullArtworkWidget` (the grey badge with a music-note icon shown when a song has no artwork or it fails to load) gives its `Icon` an explicit size smaller than the circular badge `Container` around it, but the `Container` has no `alignment`. Without one, the icon ends up off-center inside the circle instead of centered.

## Fix
Add `alignment: Alignment.center` to the badge `Container`.

## Why
A one-line, self-contained visual fix — this widget's badge/icon sizing logic is unrelated to anything else and no other behavior changes.

Noticed this while testing a downstream desktop build that reuses the same widget for album art that fails to load; it's not desktop-specific, the same widget and the same bug are used here on the main tree (e.g. any offline song missing its cached artwork).

## Testing
`flutter analyze` on the file: no issues.