### PR TITLE
feat: add recommended songs section to custom playlists

### DIFF
--- a/lib/localization/app_en.arb
+++ b/lib/localization/app_en.arb
@@ -222,6 +222,7 @@
   "recentlyPlayed": "Recently played",
   "recentlyPlayedMsg": "Recently played history cleared",
   "recommendedForYou": "Recommended for you",
+  "recommendedSongs": "Recommended songs",
   "remove": "Remove",
   "removeFromFolder": "Remove from folder",
   "removeFromLikedPlaylists": "Remove from liked playlists",

--- a/lib/localization/app_pt.arb
+++ b/lib/localization/app_pt.arb
@@ -222,6 +222,7 @@
   "recentlyPlayed": "Recentes",
   "recentlyPlayedMsg": "Histórico de reproduções recentes limpo",
   "recommendedForYou": "Recomendado para você",
+  "recommendedSongs": "Músicas recomendadas",
   "remove": "Remover",
   "removeFromFolder": "Remover da pasta",
   "removeFromLikedPlaylists": "Remover das playlists curtidas",

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -36,8 +36,8 @@ import 'package:musify/widgets/announcement_box.dart';
 import 'package:musify/widgets/listening_recap_card.dart';
 import 'package:musify/widgets/mini_player_bottom_space.dart';
 import 'package:musify/widgets/playlist_cube.dart';
+import 'package:musify/widgets/recommended_songs_section.dart';
 import 'package:musify/widgets/section_header.dart';
-import 'package:musify/widgets/song_bar.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -284,41 +284,10 @@ class _HomePageState extends State<HomePage> {
     BuildContext context,
     List<dynamic> data,
   ) {
-    final recommendedTitle = context.l10n!.recommendedForYou;
-
-    return Column(
-      children: [
-        SectionHeader(
-          title: recommendedTitle,
-          icon: FluentIcons.sparkle_24_filled,
-          actionButton: IconButton(
-            onPressed: () async {
-              await audioHandler.playPlaylistSong(
-                playlist: {'title': recommendedTitle, 'list': data},
-                songIndex: 0,
-              );
-            },
-            icon: Icon(
-              FluentIcons.play_circle_24_filled,
-              color: Theme.of(context).colorScheme.primary,
-              size: 30,
-            ),
-          ),
-        ),
-        ListView.builder(
-          shrinkWrap: true,
-          physics: const BouncingScrollPhysics(),
-          itemCount: data.length,
-          padding: commonListViewBottomPadding,
-          itemBuilder: (context, index) {
-            final borderRadius = getItemBorderRadius(index, data.length);
-            return RepaintBoundary(
-              key: listItemKey('home_recommended', index, data[index]),
-              child: SongBar(data[index], true, borderRadius: borderRadius),
-            );
-          },
-        ),
-      ],
+    return RecommendedSongsSection(
+      title: context.l10n!.recommendedForYou,
+      songs: data,
+      listKeyPrefix: 'home_recommended',
     );
   }
 }

--- a/lib/screens/playlist_page.dart
+++ b/lib/screens/playlist_page.dart
@@ -28,12 +28,14 @@ import 'package:musify/constants/app_constants.dart';
 import 'package:musify/extensions/l10n.dart';
 import 'package:musify/main.dart';
 import 'package:musify/services/artist_service.dart';
+import 'package:musify/services/common_services.dart';
 import 'package:musify/services/data_manager.dart';
 import 'package:musify/services/playlist_download_service.dart';
 import 'package:musify/services/playlist_sharing.dart';
 import 'package:musify/services/playlists_manager.dart';
 import 'package:musify/services/settings_manager.dart';
 import 'package:musify/utilities/app_utils.dart';
+import 'package:musify/utilities/async_loader.dart';
 import 'package:musify/utilities/flutter_toast.dart';
 import 'package:musify/utilities/playlist_utils.dart';
 import 'package:musify/utilities/song_filtering.dart';
@@ -49,6 +51,7 @@ import 'package:musify/widgets/playlist_page/playlist_action_buttons.dart';
 import 'package:musify/widgets/playlist_page/playlist_header.dart';
 import 'package:musify/widgets/playlist_page/playlist_sliver_app_bar.dart';
 import 'package:musify/widgets/playlist_page/search_bar_section.dart';
+import 'package:musify/widgets/recommended_songs_section.dart';
 import 'package:musify/widgets/song_bar.dart';
 import 'package:musify/widgets/sort_chips.dart';
 import 'package:musify/widgets/spinner.dart';
@@ -78,6 +81,22 @@ class _PlaylistPageState extends State<PlaylistPage> {
   late List<dynamic> _originalPlaylistList; // Keep original order separately
 
   bool _isInitializingPlaylist = true;
+
+  /// Playlist-seeded recommendations shown under custom playlists while
+  /// online. Null when the section does not apply (not user-created,
+  /// offline, or empty playlist).
+  Future<List>? _recommendedSongsFuture;
+
+  /// Ytids added from the recommended songs section during this page visit,
+  /// so an added song drops out of the (already-fetched) recommendation
+  /// list immediately instead of waiting for the next visit's refetch.
+  final Set<String> _addedRecommendedSongIds = {};
+
+  /// Max recommended songs rendered at once, purely to bound how many
+  /// artwork loads happen in a single frame. Not a "window" that refills —
+  /// it never triggers a new fetch, it just caps what's shown from the
+  /// batch already in memory.
+  static const _visibleRecommendedSongsCount = 5;
 
   String? get _resolvedPlaylistId =>
       _playlist?['ytid']?.toString() ??
@@ -159,6 +178,7 @@ class _PlaylistPageState extends State<PlaylistPage> {
         _adoptPlaylist(_playlist);
         _sortPlaylist(_sortType);
       }
+      _maybeLoadRecommendations();
     } catch (e, stackTrace) {
       logger.log(
         'Error initializing playlist:',
@@ -227,12 +247,76 @@ class _PlaylistPageState extends State<PlaylistPage> {
                     EmptyPlaylistState(
                       message: context.l10n!.noSongsInPlaylist,
                     ),
+                  _buildRecommendedSongsSliver(),
                   const SliverMiniPlayerBottomSpace(),
                 ],
               )
             : EmptyPlaylistState(message: context.l10n!.error),
       ),
     );
+  }
+
+  Widget _buildRecommendedSongsSliver() {
+    final future = _recommendedSongsFuture;
+    if (future == null) return const SliverToBoxAdapter();
+
+    return SliverToBoxAdapter(
+      child: AsyncLoader<List<dynamic>>(
+        future: future,
+        // Stay invisible until (and unless) real recommendations arrive, so a
+        // failed or empty fetch simply leaves no trace.
+        loadingWidget: const SizedBox.shrink(),
+        errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+        builder: (context, data) {
+          // Cap how many render at once: each row loads its own artwork, and
+          // building all ~15 fetched candidates in the single frame where
+          // this section appears is enough to visibly stutter on low-end
+          // devices. This is a render cap only — it doesn't refetch or
+          // backfill; the card just has fewer left to show as songs are
+          // added, same as before.
+          final visibleSongs = data
+              .where(
+                (song) =>
+                    !_addedRecommendedSongIds.contains(
+                      song['ytid']?.toString(),
+                    ),
+              )
+              .take(_visibleRecommendedSongsCount)
+              .toList();
+          if (visibleSongs.isEmpty) return const SizedBox.shrink();
+
+          return Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: RecommendedSongsSection(
+              title: context.l10n!.recommendedSongs,
+              songs: visibleSongs,
+              listKeyPrefix: 'playlist_recommended',
+              onAddSong: _handleAddRecommendedSong,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  /// Adds a recommended song straight into the current playlist. Mirrors
+  /// what the "add to playlist" dialog does, but skipped in favor of a
+  /// single tap since the target playlist is already the one on screen.
+  void _handleAddRecommendedSong(Map song) {
+    final playlistId = _resolvedPlaylistId;
+    if (playlistId == null) return;
+
+    final result = addSongInCustomPlaylist(context, playlistId, song);
+    showToast(context, result);
+
+    if (result == context.l10n!.songAdded) {
+      setState(() {
+        _addedRecommendedSongIds.add(song['ytid']?.toString() ?? '');
+        _originalPlaylistList.add(song);
+        _playlist['list'] = List<dynamic>.from(_originalPlaylistList);
+        _sortPlaylist(_sortType);
+      });
+    }
   }
 
   Widget _buildBackButton(BuildContext context) {
@@ -568,6 +652,28 @@ class _PlaylistPageState extends State<PlaylistPage> {
         return context.l10n!.artist;
       case PlaylistSortType.dateAdded:
         return context.l10n!.dateAdded;
+    }
+  }
+
+  /// Kicks off (or clears) the "recommended songs" fetch. The section only
+  /// applies to non-empty user-created playlists while online; the fetch
+  /// itself returns an empty list on failure so the section stays hidden if
+  /// the device has no connectivity despite online mode.
+  void _maybeLoadRecommendations() {
+    final isUserCreated = _playlist?['source'] == 'user-created';
+    final songs = _playlist?['list'] as List? ?? const [];
+    final playlistId = _resolvedPlaylistId;
+
+    if (isUserCreated &&
+        !offlineMode.value &&
+        songs.isNotEmpty &&
+        playlistId != null) {
+      _recommendedSongsFuture = getRecommendedSongsForPlaylist(
+        playlistId,
+        songs,
+      );
+    } else {
+      _recommendedSongsFuture = null;
     }
   }
 

--- a/lib/services/common_services.dart
+++ b/lib/services/common_services.dart
@@ -22,6 +22,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:flutter/widgets.dart';
 import 'package:hive/hive.dart';
@@ -194,10 +195,26 @@ Future<List> _getRecommendationsFromRecentlyPlayed() async {
     userRecentlyPlayed.value,
   )..shuffle()).take(5).toList();
 
+  return _getRecommendationsFromSeedSongs(recent);
+}
+
+/// Expands a handful of seed songs into their related videos and ranks the
+/// result by how high each pick appeared and how early its seed was listed.
+///
+/// This is the shared core behind both the home screen's "recommended for
+/// you" list (seeded from the user's history) and the per-playlist
+/// "recommended songs" section (seeded from the playlist's own tracks).
+Future<List> _getRecommendationsFromSeedSongs(List seedSongs) async {
+  final seeds = seedSongs
+      .whereType<Map>()
+      .where((song) => (song['ytid']?.toString() ?? '').isNotEmpty)
+      .toList();
+  if (seeds.isEmpty) return [];
+
   final scores = <String, double>{};
   final songMap = <String, Map>{};
 
-  final futures = recent.asMap().entries.map((entry) async {
+  final futures = seeds.asMap().entries.map((entry) async {
     final seedIndex = entry.key;
     final songData = entry.value;
     try {
@@ -207,7 +224,7 @@ Future<List> _getRecommendationsFromRecentlyPlayed() async {
         final s = returnSongLayout(0, related[i]);
         final id = s['ytid'];
         final positionWeight = 1.0 - (i / 8);
-        final recencyWeight = 1.0 - (seedIndex / recent.length);
+        final recencyWeight = 1.0 - (seedIndex / seeds.length);
         scores[id] = (scores[id] ?? 0) + positionWeight * recencyWeight;
         songMap[id] = s;
       }
@@ -225,6 +242,91 @@ Future<List> _getRecommendationsFromRecentlyPlayed() async {
   final sorted = scores.entries.toList()
     ..sort((a, b) => b.value.compareTo(a.value));
   return sorted.take(15).map((e) => songMap[e.key]!).toList();
+}
+
+/// Number of playlist tracks used to seed recommendations. Deliberately
+/// small: the network cost stays flat no matter how large the playlist is,
+/// and a fresh random draw each call keeps a big playlist from always
+/// surfacing the same picks.
+const _playlistRecommendationSeedCount = 5;
+
+/// Last fetched recommendations per playlist (keyed by playlist ytid). A
+/// module-level variable, so it lives only for the current app run: killing
+/// and reopening the app clears it like any other in-memory state, which is
+/// exactly when a fresh batch makes sense.
+final Map<String, List> _playlistRecommendationsCache = {};
+
+/// Recommendations seeded from a playlist's own songs rather than the user's
+/// listening history. Backs the "recommended songs" section shown under a
+/// custom playlist while online.
+///
+/// Reuses the last fetched batch for [playlistId] for as long as it still
+/// has songs that aren't already in the playlist, so reopening the same
+/// playlist doesn't refetch every time. A real fetch only happens the first
+/// time, once the cached batch runs dry, or after the app restarts (the
+/// cache is gone with it). A handful of seed tracks are sampled at random
+/// on every real fetch, so the batch itself still rotates. Returns an empty
+/// list on any failure (offline, network error) so the caller can simply
+/// hide the section.
+Future<List> getRecommendedSongsForPlaylist(
+  String playlistId,
+  List playlistSongs,
+) async {
+  try {
+    final existingIds = playlistSongs
+        .whereType<Map>()
+        .map((song) => song['ytid']?.toString())
+        .toSet();
+
+    final cached = _playlistRecommendationsCache[playlistId];
+    if (cached != null) {
+      final stillFresh = cached
+          .where((song) => !existingIds.contains(song['ytid']?.toString()))
+          .toList();
+      if (stillFresh.isNotEmpty) return stillFresh;
+    }
+
+    final seeds = _sampleSeedSongs(
+      playlistSongs,
+      _playlistRecommendationSeedCount,
+    );
+    final recommendations = await _getRecommendationsFromSeedSongs(seeds);
+    final filtered = recommendations
+        .where((song) => !existingIds.contains(song['ytid']?.toString()))
+        .toList();
+
+    _playlistRecommendationsCache[playlistId] = filtered;
+    return filtered;
+  } catch (e, stackTrace) {
+    logger.log(
+      'Error in getRecommendedSongsForPlaylist',
+      error: e,
+      stackTrace: stackTrace,
+    );
+    return [];
+  }
+}
+
+/// Uniformly samples up to [count] songs with a non-empty `ytid` in a single
+/// pass (reservoir sampling), without copying or shuffling the whole list —
+/// playlists can hold thousands of tracks.
+List<Map> _sampleSeedSongs(List songs, int count) {
+  final random = Random();
+  final reservoir = <Map>[];
+  var seen = 0;
+
+  for (final song in songs) {
+    if (song is! Map || (song['ytid']?.toString() ?? '').isEmpty) continue;
+    seen++;
+    if (reservoir.length < count) {
+      reservoir.add(song);
+    } else {
+      final slot = random.nextInt(seen);
+      if (slot < count) reservoir[slot] = song;
+    }
+  }
+
+  return reservoir;
 }
 
 Future<List> _getRecommendationsFromMixedSources() async {

--- a/lib/widgets/recommended_songs_section.dart
+++ b/lib/widgets/recommended_songs_section.dart
@@ -1,0 +1,102 @@
+/*
+ *     Copyright (C) 2026 Valeri Gokadze
+ *
+ *     Musify is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     Musify is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ *     For more information about Musify, including how to contribute,
+ *     please visit: https://github.com/gokadzev/Musify
+ */
+
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:musify/constants/app_constants.dart';
+import 'package:musify/main.dart';
+import 'package:musify/utilities/app_utils.dart';
+import 'package:musify/widgets/section_header.dart';
+import 'package:musify/widgets/song_bar.dart';
+
+/// A titled list of recommended songs with an optional "play all" button.
+///
+/// Shared by the home screen ("recommended for you") and the per-playlist
+/// "recommended songs" section so both render identically.
+class RecommendedSongsSection extends StatelessWidget {
+  const RecommendedSongsSection({
+    super.key,
+    required this.title,
+    required this.songs,
+    required this.listKeyPrefix,
+    this.showPlayButton = true,
+    this.onAddSong,
+  });
+
+  final String title;
+  final List<dynamic> songs;
+
+  /// Scope passed to [listItemKey] so each usage keeps stable, distinct keys.
+  final String listKeyPrefix;
+  final bool showPlayButton;
+
+  /// When set, each row shows a single "add" button (via [SongBar.onAdd])
+  /// instead of the full song overflow menu.
+  final void Function(Map song)? onAddSong;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SectionHeader(
+          title: title,
+          icon: FluentIcons.sparkle_24_filled,
+          actionButton: showPlayButton
+              ? IconButton(
+                  onPressed: () async {
+                    await audioHandler.playPlaylistSong(
+                      playlist: {'title': title, 'list': songs},
+                      songIndex: 0,
+                    );
+                  },
+                  icon: Icon(
+                    FluentIcons.play_circle_24_filled,
+                    color: Theme.of(context).colorScheme.primary,
+                    size: 30,
+                  ),
+                )
+              : null,
+        ),
+        ListView.builder(
+          shrinkWrap: true,
+          physics: const BouncingScrollPhysics(),
+          itemCount: songs.length,
+          padding: commonListViewBottomPadding,
+          itemBuilder: (context, index) {
+            final song = songs[index];
+            final borderRadius = getItemBorderRadius(index, songs.length);
+            return RepaintBoundary(
+              key: listItemKey(listKeyPrefix, index, song),
+              child: SongBar(
+                song,
+                true,
+                borderRadius: borderRadius,
+                onAdd: onAddSong != null && song is Map
+                    ? () => onAddSong!(song)
+                    : null,
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/song_bar.dart
+++ b/lib/widgets/song_bar.dart
@@ -308,6 +308,7 @@ class SongBar extends StatefulWidget {
     this.rank,
     this.playCount,
     this.barPadding,
+    this.onAdd,
     super.key,
   });
 
@@ -330,6 +331,12 @@ class SongBar extends StatefulWidget {
   /// Play count to show next to the artist, e.g. `1.2B`. Presentation only,
   /// like [rank]: it belongs to where the song is listed, not to the song.
   final String? playCount;
+
+  /// When set, the trailing overflow menu is replaced with a single "add"
+  /// button that calls this instead. For contexts where the only action
+  /// that makes sense is adding the song somewhere (e.g. a suggestion list),
+  /// rather than the full song menu.
+  final VoidCallback? onAdd;
 
   @override
   State<SongBar> createState() => _SongBarState();
@@ -472,20 +479,32 @@ class _SongBarState extends State<SongBar> {
                 ),
               ),
 
-              OverflowMenuButton<String>(
-                onSelected: (value) => _handleSongMenuAction(
-                  context: context,
-                  value: value,
-                  song: widget.song,
-                  ytid: _ytid,
-                  songLikeStatus: _songLikeStatus,
-                  songOfflineStatus: _songOfflineStatus,
-                  songDownloadStatus: _songDownloadStatus,
-                  onRemove: widget.onRemove,
-                  onRename: () => _handleRenameSong(context),
+              if (widget.onAdd != null)
+                IconButton(
+                  padding: EdgeInsets.zero,
+                  icon: Icon(
+                    FluentIcons.add_circle_24_regular,
+                    color: colorScheme.primary,
+                  ),
+                  tooltip: context.l10n!.addToPlaylist,
+                  onPressed: widget.onAdd,
+                )
+              else
+                OverflowMenuButton<String>(
+                  onSelected: (value) => _handleSongMenuAction(
+                    context: context,
+                    value: value,
+                    song: widget.song,
+                    ytid: _ytid,
+                    songLikeStatus: _songLikeStatus,
+                    songOfflineStatus: _songOfflineStatus,
+                    songDownloadStatus: _songDownloadStatus,
+                    onRemove: widget.onRemove,
+                    onRename: () => _handleRenameSong(context),
+                  ),
+                  itemBuilder: (context) =>
+                      _buildMenuItems(context, colorScheme),
                 ),
-                itemBuilder: (context) => _buildMenuItems(context, colorScheme),
-              ),
             ],
           ),
         ),


### PR DESCRIPTION
## What

Adds a second "Recommended songs" card under **custom (user-created) playlists**, shown only while online — the same idea as the home screen's "Recommended for you", but seeded from that playlist's own tracks instead of the user's listening history.

## Why

Custom playlists currently have no way to discover more songs that fit them. This surfaces a small, playlist-specific batch of suggestions right where you'd act on them, with a one-tap add.

## How it works

- Reuses the existing recommendation core (`_getRecommendationsFromSeedSongs`) that already powers the home screen — no duplicated scoring logic. A few random tracks from the playlist are used as seeds instead of recently-played songs.
- Each row has a simple **add (+) button** instead of the full song overflow menu — tapping it adds that song straight into the playlist with one tap.
- The batch is cached per playlist in memory for the life of the app session: reopening the same playlist reuses it instead of refetching, and only refetches for real once the cache runs out of songs that aren't already in the playlist (or the app restarts).
- Only up to 5 rows render at once, capped independently of the fetch size, so artwork loading doesn't land in a single frame on lower-end devices.
- Section is gated on: playlist is user-created, app is online, playlist is non-empty. The fetch itself swallows all errors and returns an empty list on failure, so a device that's nominally "online" but has no real connectivity just doesn't show the card, rather than showing an error.

## Explicitly out of scope for this PR

Kept deliberately minimal per review feedback. For a future iteration:
- A manual "refresh recommendations" button on the card
- Refetching (rather than just shrinking) once the visible list runs out from adds, instead of waiting for the cache to fully exhaust
